### PR TITLE
Make documentation work using Play 2.3-SNAPSHOT

### DIFF
--- a/documentation/project/DocValidation.scala
+++ b/documentation/project/DocValidation.scala
@@ -7,7 +7,7 @@ import org.pegdown.ast._
 import org.pegdown.ast.Node
 import org.pegdown.plugins.{ToHtmlSerializerPlugin, PegDownPlugins}
 import org.pegdown._
-import play.console.Colors
+import play.sbtplugin.Colors
 import play.doc.{CodeReferenceNode, CodeReferenceParser}
 import sbt._
 import sbt.Keys._
@@ -15,7 +15,6 @@ import sbt.File
 import scala.collection.mutable
 import scala.concurrent.duration.Duration
 import scala.concurrent.{Await, Future, ExecutionContext}
-import scala.Some
 import scala.util.control.NonFatal
 
 // Test that all the docs are renderable and valid

--- a/documentation/project/build.properties
+++ b/documentation/project/build.properties
@@ -1,4 +1,4 @@
 #
 # Copyright (C) 2009-2013 Typesafe Inc. <http://www.typesafe.com>
 #
-sbt.version=0.13.0
+sbt.version=0.13.5-M2

--- a/documentation/project/plugins.sbt
+++ b/documentation/project/plugins.sbt
@@ -7,6 +7,10 @@ logLevel := Level.Warn
 resolvers += "Typesafe repository" at "http://repo.typesafe.com/typesafe/releases/"
 
 // Use the Play sbt plugin for Play projects
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % Option(System.getProperty("play.version")).get)
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % Option(System.getProperty("play.version")).getOrElse {
+  println("[\033[31merror\033[0m] No play.version system property specified.\n[\033[31merror\033[0m] Just use the build script to launch SBT and life will be much easier.")
+  System.exit(1)
+  throw new RuntimeException("No play version")
+})
 
 libraryDependencies += "com.typesafe.play" %% "play-doc" % "1.0.3"


### PR DESCRIPTION
The documentation sub-project currently does not build.  This PR updates the build so that it works with Play 2.3-SNAPSHOT (basically just copied the documentation build files from Play).

To run,

``` shell
$ cd documentation
$ sbt -Dplay.version=2.3-SNAPSHOT run
```
