### PR TITLE
[Form] Allow to follow a deep empty path

### DIFF
--- a/validation-form/src/main/scala/play/api/data/mapping/forms/Rules.scala
+++ b/validation-form/src/main/scala/play/api/data/mapping/forms/Rules.scala
@@ -157,10 +157,7 @@ object Rules extends DefaultRules[PM.PM] with ParsingRules {
 
   implicit def pickInPM[O](p: Path)(implicit r: RuleLike[PM, O]): Rule[PM, O] =
     Rule[PM, PM] { pm =>
-      PM.find(p)(pm) match {
-        case sub if sub.isEmpty => Failure(Seq(Path -> Seq(ValidationError("error.required"))))
-        case sub => Success(sub)
-      }
+      Success(PM.find(p)(pm))
     }.compose(r)
 
   // Convert Rules exploring PM, to Rules exploring UrlFormEncoded

--- a/validation-form/src/test/scala/play/api/data/mapping/forms/FormatSpec.scala
+++ b/validation-form/src/test/scala/play/api/data/mapping/forms/FormatSpec.scala
@@ -27,7 +27,7 @@ object FormatSpec extends Specification {
       f.writes(1L) mustEqual(m)
       f.validate(m) mustEqual(Success(1L))
 
-      (Path \ "id").from[UrlFormEncoded](f).validate(Map.empty) mustEqual(Failure(Seq(Path \ "id" -> Seq(ValidationError("error.required")))))
+      (f).validate(Map.empty) mustEqual(Failure(Seq(Path \ "id" -> Seq(ValidationError("error.required")))))
     }
 
 
@@ -44,7 +44,7 @@ object FormatSpec extends Specification {
       f.writes("CAFEBABE") mustEqual(m)
       f.validate(m) mustEqual(Success("CAFEBABE"))
 
-      (Path \ "id").from[UrlFormEncoded](f).validate(Map.empty) mustEqual(Failure(Seq(Path \ "id" -> Seq(ValidationError("error.required")))))
+      (f).validate(Map.empty) mustEqual(Failure(Seq(Path \ "id" -> Seq(ValidationError("error.required")))))
     }
 
     "serialize and deserialize Seq[String]" in {
@@ -231,7 +231,7 @@ object FormatSpec extends Specification {
       "Map[String, Seq[V]]" in {
         Formatting[UrlFormEncoded, UrlFormEncoded] { __ => (__ \ "n").format[Map[String, Seq[String]]] }.validate(Map("n.foo" -> Seq("bar"))) mustEqual(Success(Map("foo" -> Seq("bar"))))
         Formatting[UrlFormEncoded, UrlFormEncoded] { __ => (__ \ "n").format[Map[String, Seq[Int]]] }.validate(Map("n.foo" -> Seq("4"), "n.bar" -> Seq("5"))) mustEqual(Success(Map("foo" -> Seq(4), "bar" -> Seq(5))))
-        Formatting[UrlFormEncoded, UrlFormEncoded] { __ => (__ \ "x").format[Map[String, Int]] }.validate(Map("n.foo" -> Seq("4"), "n.bar" -> Seq("frack"))) mustEqual(Failure(Seq(Path \ "x" -> Seq(ValidationError("error.required")))))
+        Formatting[UrlFormEncoded, UrlFormEncoded] { __ => (__ \ "x").format[Map[String, Int]] }.validate(Map("n.foo" -> Seq("4"), "n.bar" -> Seq("frack"))) mustEqual(Success(Map.empty))
         Formatting[UrlFormEncoded, UrlFormEncoded] { __ => (__ \ "n").format[Map[String, Seq[Int]]] }.validate(Map("n.foo" -> Seq("4"), "n.bar" -> Seq("frack"))) mustEqual(Failure(Seq(Path \ "n" \ "bar" \ 0 -> Seq(ValidationError("error.number", "Int")))))
       }
 

--- a/validation-form/src/test/scala/play/api/data/mapping/forms/RulesSpec.scala
+++ b/validation-form/src/test/scala/play/api/data/mapping/forms/RulesSpec.scala
@@ -204,7 +204,7 @@ object RulesSpec extends Specification {
       "Map[String, Seq[V]]" in {
         From[UrlFormEncoded] { __ => (__ \ "n").read[Map[String, Seq[String]]] }.validate(Map("n.foo" -> Seq("bar"))) mustEqual(Success(Map("foo" -> Seq("bar"))))
         From[UrlFormEncoded] { __ => (__ \ "n").read[Map[String, Seq[Int]]] }.validate(Map("n.foo" -> Seq("4"), "n.bar" -> Seq("5"))) mustEqual(Success(Map("foo" -> Seq(4), "bar" -> Seq(5))))
-        From[UrlFormEncoded] { __ => (__ \ "x").read[Map[String, Int]] }.validate(Map("n.foo" -> Seq("4"), "n.bar" -> Seq("frack"))) mustEqual(Failure(Seq(Path \ "x" -> Seq(ValidationError("error.required")))))
+        From[UrlFormEncoded] { __ => (__ \ "x").read[Map[String, Int]] }.validate(Map("n.foo" -> Seq("4"), "n.bar" -> Seq("frack"))) mustEqual(Success(Map.empty))
         From[UrlFormEncoded] { __ => (__ \ "n").read[Map[String, Seq[Int]]] }.validate(Map("n.foo" -> Seq("4"), "n.bar" -> Seq("frack"))) mustEqual(Failure(Seq(Path \ "n" \ "bar" \ 0 -> Seq(ValidationError("error.number", "Int")))))
       }
 
@@ -266,6 +266,12 @@ object RulesSpec extends Specification {
          (__ \ "informations").read(
           (__ \ "label").read(notEmpty))
       }.validate(invalid) mustEqual(Failure(Seq(p -> Seq(ValidationError("error.required")))))
+    }
+
+    "validate deep optional" in {
+      From[UrlFormEncoded]{ __ =>
+        (__ \ "first" \ "second").read[Option[String]]
+      }validate(Map.empty) mustEqual Success(None)
     }
 
     "coerce type" in {

--- a/validation-json/src/test/scala/play/api/data/validation/json/RulesSpec.scala
+++ b/validation-json/src/test/scala/play/api/data/validation/json/RulesSpec.scala
@@ -250,6 +250,12 @@ object RulesSpec extends Specification {
       }.validate(invalid) mustEqual(Failure(Seq(p -> Seq(ValidationError("error.required")))))
     }
 
+    "validate deep optional" in {
+      From[JsValue]{ __ =>
+        (__ \ "first" \ "second").read[Option[String]]
+      }validate(JsNull) mustEqual Success(None)
+    }
+
     "coerce type" in {
       (Path \ "age").read[JsValue, Int].validate(valid) mustEqual(Success(27))
       (Path \ "age").from[JsValue](min(20)).validate(valid) mustEqual(Success(27))

--- a/validation-json4s/src/test/scala/play/api/data/validation/json/RulesSpec.scala
+++ b/validation-json4s/src/test/scala/play/api/data/validation/json/RulesSpec.scala
@@ -251,6 +251,12 @@ object RulesSpec extends Specification {
       }.validate(invalid) mustEqual(Failure(Seq(p -> Seq(ValidationError("error.required")))))
     }
 
+    "validate deep optional" in {
+      From[JValue]{ __ =>
+        (__ \ "first" \ "second").read[Option[String]]
+      }validate(JNull) mustEqual Success(None)
+    }
+
     "coerce type" in {
       (Path \ "age").read[JValue, Int].validate(valid) mustEqual(Success(27))
       (Path \ "age").from[JValue](min(20)).validate(valid) mustEqual(Success(27))

--- a/validation-xml/src/test/scala/play.api.data.mapping.xml/RulesSpec.scala
+++ b/validation-xml/src/test/scala/play.api.data.mapping.xml/RulesSpec.scala
@@ -217,6 +217,12 @@ object RulesSpec extends Specification {
         }.validate(invalid) mustEqual(Failure(Seq((p \ "foo") -> Seq(ValidationError("error.required")))))
       }
 
+      "validate deep optional" in {
+        From[Node]{ __ =>
+          (__ \ "first" \ "second").read[Option[String]]
+        }validate(invalid) mustEqual Success(None)
+      }
+
       "coerce type" in {
         (Path \ "age").read[Node, Int].validate(valid) mustEqual(Success(27))
         (Path \ "age").from[Node](min(20)).validate(valid) mustEqual(Success(27))


### PR DESCRIPTION
I believe the "error.required" should mot be raised in `pickInPM` even on an empty path.
This allow : 

    (__ \ "first" \ "second").read[Option[String]]
Not to fail and return `None`.

This PR is not ready to merge because the comportment in certain case is not coherent between Json/Form/Xml. The main example is that after the change

     From[UrlFormEncoded] { __ => (__ \ "x").read[Map[String, Int]] }

called on an empty `UrlFormEncoded` will return an empty `Map`, when a similar test for the Json part will fail.  
I believe returning an empty `Map` should be prefered but wanted your opinion before making more changes. 