### PR TITLE
[Fix] Enable writes of value classes

### DIFF
--- a/validation-form/src/main/scala/play/api/data/mapping/forms/Writes.scala
+++ b/validation-form/src/main/scala/play/api/data/mapping/forms/Writes.scala
@@ -18,7 +18,13 @@ object Writes extends DefaultWrites with GenericWrites[PM.PM] with DefaultMonoid
   import PM._
 
   // TODO: accept a format ?
-  implicit def anyval[T <: AnyVal] = Write((i: T) => i.toString)
+  implicit val intW: Write[Int, String] = Write(_.toString)
+  implicit val shortW: Write[Short, String] = Write(_.toString)
+  implicit val booleanW: Write[Boolean, String] = Write(_.toString)
+  implicit val longW: Write[Long, String] = Write(_.toString)
+  implicit val floatW: Write[Float, String] = Write(_.toString)
+  implicit val doubleW: Write[Double, String] = Write(_.toString)
+  implicit val bigDecimalW: Write[BigDecimal, String] = Write(_.toString)
   implicit def scalanumber[T <: scala.math.ScalaNumber] = Write((i: T) => i.toString)
   implicit def javanumber[T <: java.lang.Number] = Write((i: T) => i.toString)
 

--- a/validation-form/src/test/scala/play/api/data/mapping/forms/WritesSpec.scala
+++ b/validation-form/src/test/scala/play/api/data/mapping/forms/WritesSpec.scala
@@ -309,17 +309,16 @@ class WritesSpec extends Specification {
         }
         w3.writes(u1) mustEqual m1
       }
+    }
+    
+    "support write of value class" in {
+      import TestValueClass._
 
-      "support write of value class" in {
-        import TestValueClass._
-
-        val w = To[UrlFormEncoded] { __ =>
-          (__ \ "id").write[Id]
-        }
-
-        w.writes(Id("1")) mustEqual Map("id" -> Seq("1"))
+      val w = To[UrlFormEncoded] { __ =>
+        (__ \ "id").write[Id]
       }
 
+      w.writes(Id("1")) mustEqual Map("id" -> Seq("1"))
     }
 
   }

--- a/validation-form/src/test/scala/play/api/data/mapping/forms/WritesSpec.scala
+++ b/validation-form/src/test/scala/play/api/data/mapping/forms/WritesSpec.scala
@@ -48,8 +48,8 @@ class WritesSpec extends Specification {
       w.writes(Some("Hello World")) mustEqual Map("email" -> Seq("Hello World"))
       w.writes(None) mustEqual Map.empty
 
-      (Path \ "n").write(optionW(anyval[Int])).writes(Some(5)) mustEqual Map("n" -> Seq("5"))
-      (Path \ "n").write(optionW(anyval[Int])).writes(None) mustEqual Map.empty
+      (Path \ "n").write(optionW(intW)).writes(Some(5)) mustEqual Map("n" -> Seq("5"))
+      (Path \ "n").write(optionW(intW)).writes(None) mustEqual Map.empty
 
       case class Foo(name: String)
       implicit val wf = (Path \ "name").write[String, UrlFormEncoded].contramap((_: Foo).name)
@@ -310,8 +310,27 @@ class WritesSpec extends Specification {
         w3.writes(u1) mustEqual m1
       }
 
+      "support write of value class" in {
+        import TestValueClass._
+
+        val w = To[UrlFormEncoded] { __ =>
+          (__ \ "id").write[Id]
+        }
+
+        w.writes(Id("1")) mustEqual Map("id" -> Seq("1"))
+      }
+
     }
 
   }
 
 }
+
+object TestValueClass {
+  case class Id(value: String) extends AnyVal
+  object Id {
+    import play.api.data.mapping.forms.Writes._
+    implicit val writes: Write[Id, String] = Write(id => id.value)
+  }
+}
+

--- a/validation-json/src/main/scala/play/api/data/mapping/json/Writes.scala
+++ b/validation-json/src/main/scala/play/api/data/mapping/json/Writes.scala
@@ -52,8 +52,14 @@ object Writes extends DefaultWrites with DefaultMonoids with GenericWrites[JsVal
     Write(s => JsString(s))
 
   private def tToJs[T] = Write[T, JsValue]((i: T) => JsNumber(BigDecimal(i.toString)))
-  implicit def anyval[T <: AnyVal] = tToJs[T]
   implicit def javanumber[T <: java.lang.Number] = tToJs[T]
+
+  implicit val intW = tToJs[Int]
+  implicit val shortW = tToJs[Short]
+  implicit val longW = tToJs[Long]
+  implicit val floatW = tToJs[Float]
+  implicit val doubleW = tToJs[Double]
+  implicit val bigDecimalW = Write[BigDecimal, JsValue](JsNumber.apply _)
 
   implicit def booleanW = Write[Boolean, JsValue](JsBoolean.apply _)
 

--- a/validation-json/src/test/scala/play/api/data/validation/json/WritesSpec.scala
+++ b/validation-json/src/test/scala/play/api/data/validation/json/WritesSpec.scala
@@ -327,6 +327,8 @@ class WritesSpec extends Specification {
     }
 
     "support write of value class" in {
+      import TestValueClass._
+
       val w = To[JsObject] { __ =>
         (__ \ "id").write[Id]
       }
@@ -338,8 +340,10 @@ class WritesSpec extends Specification {
 
 }
 
-case class Id(value: String) extends AnyVal
-object Id {
-  import play.api.data.mapping.Write
-  implicit val writes: Write[Id, JsString] = Write(id => JsString(id.value))
+object TestValueClass {
+  case class Id(value: String) extends AnyVal
+  object Id {
+    import play.api.data.mapping.Write
+    implicit val writes: Write[Id, JsString] = Write(id => JsString(id.value))
+  }
 }

--- a/validation-json/src/test/scala/play/api/data/validation/json/WritesSpec.scala
+++ b/validation-json/src/test/scala/play/api/data/validation/json/WritesSpec.scala
@@ -48,8 +48,8 @@ class WritesSpec extends Specification {
       w.writes(Some("Hello World")) mustEqual Json.obj("email" -> "Hello World")
       w.writes(None) mustEqual Json.obj()
 
-      (Path \ "n").write(optionW(anyval[Int])).writes(Some(5)) mustEqual Json.obj("n" -> 5)
-      (Path \ "n").write(optionW(anyval[Int])).writes(None) mustEqual Json.obj()
+      (Path \ "n").write(optionW(intW)).writes(Some(5)) mustEqual Json.obj("n" -> 5)
+      (Path \ "n").write(optionW(intW)).writes(None) mustEqual Json.obj()
     }
 
     "write seq" in {
@@ -326,6 +326,20 @@ class WritesSpec extends Specification {
 
     }
 
+    "support write of value class" in {
+      val w = To[JsObject] { __ =>
+        (__ \ "id").write[Id]
+      }
+
+      w.writes(Id("1")) mustEqual Json.obj("id" -> "1")
+    }
+
   }
 
+}
+
+case class Id(value: String) extends AnyVal
+object Id {
+  import play.api.data.mapping.Write
+  implicit val writes: Write[Id, JsString] = Write(id => JsString(id.value))
 }

--- a/validation-json4s/src/main/scala/play/api/data/mapping/json/Writes.scala
+++ b/validation-json4s/src/main/scala/play/api/data/mapping/json/Writes.scala
@@ -60,7 +60,12 @@ object Writes extends DefaultWrites with DefaultMonoids with GenericWrites[JValu
     case i => JDecimal(BigDecimal(i.toString))
   }
 
-  implicit def anyval[T <: AnyVal] = tToJs[T]
+  implicit val intW = tToJs[Int]
+  implicit val shortW = tToJs[Short]
+  implicit val longW = tToJs[Long]
+  implicit val floatW = tToJs[Float]
+  implicit val doubleW = tToJs[Double]
+  implicit val bigDecimalW = Write[BigDecimal, JValue](JDecimal.apply _)
   implicit def javanumber[T <: java.lang.Number] = tToJs[T]
 
   implicit def booleanW = Write[Boolean, JValue](JBool.apply _)

--- a/validation-json4s/src/test/scala/play/api/data/validation/json/WritesSpec.scala
+++ b/validation-json4s/src/test/scala/play/api/data/validation/json/WritesSpec.scala
@@ -49,8 +49,8 @@ class WritesSpec extends Specification {
       w.writes(Some("Hello World")) mustEqual JObject("email" -> JString("Hello World"))
       w.writes(None) mustEqual JObject()
 
-      (Path \ "n").write(optionW(anyval[Int])).writes(Some(5)) mustEqual JObject("n" -> JInt(5))
-      (Path \ "n").write(optionW(anyval[Int])).writes(None) mustEqual JObject()
+      (Path \ "n").write(optionW(intW)).writes(Some(5)) mustEqual JObject("n" -> JInt(5))
+      (Path \ "n").write(optionW(intW)).writes(None) mustEqual JObject()
     }
 
     "write seq" in {
@@ -327,6 +327,26 @@ class WritesSpec extends Specification {
 
     }
 
+    "support write of value class" in {
+      import TestValueClass._
+
+      val w = To[JObject] { __ =>
+        (__ \ "id").write[Id]
+      }
+
+      w.writes(Id("1")) mustEqual JObject("id" -> JString("1"))
+    }
+
   }
 
 }
+
+object TestValueClass {
+  case class Id(value: String) extends AnyVal
+  object Id {
+    import play.api.data.mapping.Write
+    implicit val writes: Write[Id, JString] = Write(id => JString(id.value))
+  }
+}
+
+


### PR DESCRIPTION
Hello,

I have noticed a bug in all Writes (json, form) when one wants to define a Write of a custom value class. This due to the fact that AnyVal is used to create writes for all the numeric value types, which has the side-effect of including custom value classes.

Example in validation-json:
```scala
case class Id(value: String) extends AnyVal
object Id {
  implicit val writes: Write[Id, JsString] = Write(id => JsString(id.value))
}

val w = To[JsObject] { __ =>
  (__ \ "id").write[Id]
}

w.writes(Id("1")) mustEqual Json.obj("id" -> "1")
```
This resulted in write[Id] using the anyval write and thus trying to construct a BigDecimal of Id.

This PR fixes the issue for json, json4s and form.
