### PR TITLE
[Forms] Implement the [] rule for UrlFormEncoded

### DIFF
--- a/validation-form/src/main/scala/play/api/data/mapping/forms/Rules.scala
+++ b/validation-form/src/main/scala/play/api/data/mapping/forms/Rules.scala
@@ -57,9 +57,10 @@ object PM {
   def toPM(m: UrlFormEncoded): PM =
     m.toSeq.flatMap {
       case (p, vs) =>
-        vs match {
-          case Seq(v) => vs.map { asPath(p) -> _ }
-          case _ => vs.zipWithIndex.map { case (v, i) => (asPath(p) \ i) -> v }
+        if( p.endsWith("[]") ) {
+          vs.zipWithIndex.map { case (v, i) => (asPath(p.dropRight(2)) \ i) -> v }
+        } else {
+          vs.headOption.map { asPath(p) -> _ }.toSeq
         }
     }.toMap
 

--- a/validation-form/src/test/scala/play/api/data/mapping/forms/FormatSpec.scala
+++ b/validation-form/src/test/scala/play/api/data/mapping/forms/FormatSpec.scala
@@ -237,25 +237,25 @@ object FormatSpec extends Specification {
 
       "Traversable" in {
         Formatting[UrlFormEncoded, UrlFormEncoded] { __ => (__ \ "n").format[Traversable[String]] }.validate(Map("n" -> Seq("foo"))).get.toSeq must contain(exactly(Seq("foo"): _*))
-        Formatting[UrlFormEncoded, UrlFormEncoded] { __ => (__ \ "n").format[Traversable[Int]] }.validate(Map("n" -> Seq("1", "2", "3"))).get.toSeq must contain(exactly(Seq(1, 2, 3): _*))
-        Formatting[UrlFormEncoded, UrlFormEncoded] { __ => (__ \ "n").format[Traversable[Int]] }.validate(Map("n" -> Seq("1", "paf"))) mustEqual(Failure(Seq(Path \ "n" \ 1 -> Seq(ValidationError("error.number", "Int")))))
+        Formatting[UrlFormEncoded, UrlFormEncoded] { __ => (__ \ "n").format[Traversable[Int]] }.validate(Map("n[]" -> Seq("1", "2", "3"))).get.toSeq must contain(exactly(Seq(1, 2, 3): _*))
+        Formatting[UrlFormEncoded, UrlFormEncoded] { __ => (__ \ "n").format[Traversable[Int]] }.validate(Map("n[]" -> Seq("1", "paf"))) mustEqual(Failure(Seq(Path \ "n" \ 1 -> Seq(ValidationError("error.number", "Int")))))
       }
 
       "Array" in {
         Formatting[UrlFormEncoded, UrlFormEncoded] { __ => (__ \ "n").format[Array[String]] }.validate(Map("n" -> Seq("foo"))).get.toSeq must contain(exactly(Seq("foo"): _*))
-        Formatting[UrlFormEncoded, UrlFormEncoded] { __ => (__ \ "n").format[Array[Int]] }.validate(Map("n" -> Seq("1", "2", "3"))).get.toSeq must contain(exactly(Seq(1, 2, 3): _*))
-        Formatting[UrlFormEncoded, UrlFormEncoded] { __ => (__ \ "n").format[Array[Int]] }.validate(Map("n" -> Seq("1", "paf"))) mustEqual(Failure(Seq(Path \ "n" \ 1 -> Seq(ValidationError("error.number", "Int")))))
+        Formatting[UrlFormEncoded, UrlFormEncoded] { __ => (__ \ "n").format[Array[Int]] }.validate(Map("n[]" -> Seq("1", "2", "3"))).get.toSeq must contain(exactly(Seq(1, 2, 3): _*))
+        Formatting[UrlFormEncoded, UrlFormEncoded] { __ => (__ \ "n").format[Array[Int]] }.validate(Map("n[]" -> Seq("1", "paf"))) mustEqual(Failure(Seq(Path \ "n" \ 1 -> Seq(ValidationError("error.number", "Int")))))
       }
 
       "Seq" in {
         Formatting[UrlFormEncoded, UrlFormEncoded] { __ => (__ \ "n").format[Seq[String]] }.validate(Map("n" -> Seq("foo"))).get must contain(exactly(Seq("foo"): _*))
-        Formatting[UrlFormEncoded, UrlFormEncoded] { __ => (__ \ "n").format[Seq[Int]] }.validate(Map("n" -> Seq("1", "2", "3"))).get must contain(exactly(Seq(1, 2, 3): _*))
+        Formatting[UrlFormEncoded, UrlFormEncoded] { __ => (__ \ "n").format[Seq[Int]] }.validate(Map("n[]" -> Seq("1", "2", "3"))).get must contain(exactly(Seq(1, 2, 3): _*))
         Formatting[UrlFormEncoded, UrlFormEncoded] { __ => (__ \ "n").format[Seq[Int]] }.validate(Map(
           "n[0]" -> Seq("1"),
           "n[1]" -> Seq("2"),
           "n[3]" -> Seq("3")
         )).get must contain(exactly(Seq(1, 2, 3): _*))
-        Formatting[UrlFormEncoded, UrlFormEncoded] { __ => (__ \ "n").format[Seq[Int]] }.validate(Map("n" -> Seq("1", "paf"))) mustEqual(Failure(Seq(Path \ "n" \ 1 -> Seq(ValidationError("error.number", "Int")))))
+        Formatting[UrlFormEncoded, UrlFormEncoded] { __ => (__ \ "n").format[Seq[Int]] }.validate(Map("n[]" -> Seq("1", "paf"))) mustEqual(Failure(Seq(Path \ "n" \ 1 -> Seq(ValidationError("error.number", "Int")))))
       }
     }
 

--- a/validation-form/src/test/scala/play/api/data/mapping/forms/RulesSpec.scala
+++ b/validation-form/src/test/scala/play/api/data/mapping/forms/RulesSpec.scala
@@ -11,12 +11,12 @@ object RulesSpec extends Specification {
     import Rules._
     import PM._
     val valid: UrlFormEncoded = Map(
-      "firstname" -> Seq("Julien"),
+      "firstname" -> Seq("Julien", "ignored"),
       "lastname" -> Seq("Tournay"),
       "age" -> Seq("27"),
       "informations.label" -> Seq("Personal"),
       "informations.email" -> Seq("fakecontact@gmail.com"),
-      "informations.phones" -> Seq("01.23.45.67.89", "98.76.54.32.10"))
+      "informations.phones[]" -> Seq("01.23.45.67.89", "98.76.54.32.10"))
 
     val invalid = Map(
      "firstname" -> Seq("Julien"),
@@ -24,7 +24,7 @@ object RulesSpec extends Specification {
      "age" -> Seq("27"),
      "informations.label" -> Seq(""),
      "informations.email" -> Seq("fakecontact@gmail.com"),
-     "informations.phones" -> Seq("01.23.45.67.89", "98.76.54.32.10"))
+     "informations.phones[]" -> Seq("01.23.45.67.89", "98.76.54.32.10"))
 
     "extract data" in {
       From[UrlFormEncoded] { __ =>
@@ -210,25 +210,25 @@ object RulesSpec extends Specification {
 
       "Traversable" in {
         From[UrlFormEncoded] { __ => (__ \ "n").read[Traversable[String]] }.validate(Map("n" -> Seq("foo"))).get.toSeq must contain(exactly(Seq("foo"): _*))
-        From[UrlFormEncoded] { __ => (__ \ "n").read[Traversable[Int]] }.validate(Map("n" -> Seq("1", "2", "3"))).get.toSeq must contain(exactly(Seq(1, 2, 3): _*))
-        From[UrlFormEncoded] { __ => (__ \ "n").read[Traversable[Int]] }.validate(Map("n" -> Seq("1", "paf"))) mustEqual(Failure(Seq(Path \ "n" \ 1 -> Seq(ValidationError("error.number", "Int")))))
+        From[UrlFormEncoded] { __ => (__ \ "n").read[Traversable[Int]] }.validate(Map("n[]" -> Seq("1", "2", "3"))).get.toSeq must contain(exactly(Seq(1, 2, 3): _*))
+        From[UrlFormEncoded] { __ => (__ \ "n").read[Traversable[Int]] }.validate(Map("n[]" -> Seq("1", "paf"))) mustEqual(Failure(Seq(Path \ "n" \ 1 -> Seq(ValidationError("error.number", "Int")))))
       }
 
       "Array" in {
         From[UrlFormEncoded] { __ => (__ \ "n").read[Array[String]] }.validate(Map("n" -> Seq("foo"))).get.toSeq must contain(exactly(Seq("foo"): _*))
-        From[UrlFormEncoded] { __ => (__ \ "n").read[Array[Int]] }.validate(Map("n" -> Seq("1", "2", "3"))).get.toSeq must contain(exactly(Seq(1, 2, 3): _*))
-        From[UrlFormEncoded] { __ => (__ \ "n").read[Array[Int]] }.validate(Map("n" -> Seq("1", "paf"))) mustEqual(Failure(Seq(Path \ "n" \ 1 -> Seq(ValidationError("error.number", "Int")))))
+        From[UrlFormEncoded] { __ => (__ \ "n").read[Array[Int]] }.validate(Map("n[]" -> Seq("1", "2", "3"))).get.toSeq must contain(exactly(Seq(1, 2, 3): _*))
+        From[UrlFormEncoded] { __ => (__ \ "n").read[Array[Int]] }.validate(Map("n[]" -> Seq("1", "paf"))) mustEqual(Failure(Seq(Path \ "n" \ 1 -> Seq(ValidationError("error.number", "Int")))))
       }
 
       "Seq" in {
         From[UrlFormEncoded] { __ => (__ \ "n").read[Seq[String]] }.validate(Map("n" -> Seq("foo"))).get must contain(exactly(Seq("foo"): _*))
-        From[UrlFormEncoded] { __ => (__ \ "n").read[Seq[Int]] }.validate(Map("n" -> Seq("1", "2", "3"))).get must contain(exactly(Seq(1, 2, 3): _*))
+        From[UrlFormEncoded] { __ => (__ \ "n").read[Seq[Int]] }.validate(Map("n[]" -> Seq("1", "2", "3"))).get must contain(exactly(Seq(1, 2, 3): _*))
         From[UrlFormEncoded] { __ => (__ \ "n").read[Seq[Int]] }.validate(Map(
           "n[0]" -> Seq("1"),
           "n[1]" -> Seq("2"),
           "n[3]" -> Seq("3")
         )).get must contain(exactly(Seq(1, 2, 3): _*))
-        From[UrlFormEncoded] { __ => (__ \ "n").read[Seq[Int]] }.validate(Map("n" -> Seq("1", "paf"))) mustEqual(Failure(Seq(Path \ "n" \ 1 -> Seq(ValidationError("error.number", "Int")))))
+        From[UrlFormEncoded] { __ => (__ \ "n").read[Seq[Int]] }.validate(Map("n[]" -> Seq("1", "paf"))) mustEqual(Failure(Seq(Path \ "n" \ 1 -> Seq(ValidationError("error.number", "Int")))))
       }
     }
 
@@ -389,7 +389,7 @@ object RulesSpec extends Specification {
         "age" -> Seq("27"),
         "informations[0].label" -> Seq("Personal"),
         "informations[0].email" -> Seq("fakecontact@gmail.com"),
-        "informations[0].phones" -> Seq("01.23.45.67.89", "98.76.54.32.10"))
+        "informations[0].phones[]" -> Seq("01.23.45.67.89", "98.76.54.32.10"))
 
       val validNoMail1 = Map(
         "firstname" -> Seq("Julien"),
@@ -397,7 +397,7 @@ object RulesSpec extends Specification {
         "age" -> Seq("27"),
         "informations[0].label" -> Seq("Personal"),
         "informations[0].email" -> Seq(),
-        "informations[0].phones" -> Seq("01.23.45.67.89", "98.76.54.32.10"))
+        "informations[0].phones[]" -> Seq("01.23.45.67.89", "98.76.54.32.10"))
 
       val validNoMail3 = Map(
         "firstname" -> Seq("Julien"),
@@ -405,14 +405,14 @@ object RulesSpec extends Specification {
         "age" -> Seq("27"),
         "informations[0].label" -> Seq("Personal"),
         "informations[0].email" -> Seq(""),
-        "informations[0].phones" -> Seq("01.23.45.67.89", "98.76.54.32.10"))
+        "informations[0].phones[]" -> Seq("01.23.45.67.89", "98.76.54.32.10"))
 
       val validNoMail2 = Map(
         "firstname" -> Seq("Julien"),
         "lastname" -> Seq("Tournay"),
         "age" -> Seq("27"),
         "informations[0].label" -> Seq("Personal"),
-        "informations[0].phones" -> Seq("01.23.45.67.89", "98.76.54.32.10"))
+        "informations[0].phones[]" -> Seq("01.23.45.67.89", "98.76.54.32.10"))
 
       val validWithPhones = Map(
         "firstname" -> Seq("Julien"),


### PR DESCRIPTION
When a parameter is specified multiple time as in :
    
    val data = Map("field" -> Seq("value1", "value2"))
    From[UrlFormEncoded] { __ => (__ \ "field").read[String] }.validate(data)

The validation fail with `error.required`

    Failure(List((/field,List(ValidationError(error.required,WrappedArray())))))

This is not practical and the error message dot not match the problem (`\ field` has been transformed to  `\ field \ 0` and `\ field \ 1`).

This transformation is only needed for select multiple I believe and is incompatible with having multiple input in the same page (with some hidden for example) or just an url with multiple times the same parameter (not very useful but the `error.required` do not match the problem).

This PR implement the same logic than in Play [`Form.scala`](https://github.com/playframework/playframework/blob/master/framework/src/play/src/main/scala/play/api/data/Form.scala#L93-L94) :
    
    case (s, (key, values)) if key.endsWith("[]") => s ++ values.zipWithIndex.map { case (v, i) => (key.dropRight(2) + "[" + i + "]") -> v }
    case (s, (key, values)) => s + (key -> values.headOption.getOrElse(""))
