### PR TITLE
Upgrade tut to 0.4.0

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -3,4 +3,4 @@ resolvers += Resolver.url(
     url("http://dl.bintray.com/content/tpolecat/sbt-plugin-releases"))(
         Resolver.ivyStylePatterns)
 
-addSbtPlugin("org.tpolecat" % "tut-plugin" % "0.3.2")
+addSbtPlugin("org.tpolecat" % "tut-plugin" % "0.4.0")


### PR DESCRIPTION
"tut is now run in the Test scope, which means (a) you can include test examples, and (b) the tut runtime does not become a transitive dependency of your project."