### PR TITLE
Change `(__ \ "path").format` to match the `.read` and `.write` behavior

### DIFF
--- a/validation-core/src/main/scala/play/api/data/mapping/Formatter.scala
+++ b/validation-core/src/main/scala/play/api/data/mapping/Formatter.scala
@@ -150,8 +150,11 @@ case class Formatter[IR, IW](path: Path = Path(Nil)) {
     Format[IR, IW, O](Reader(path).read(subR), Writer(path).write(subW))
   }
 
-  def format[J, O](subR: => RuleLike[J, O])(implicit r: Path => RuleLike[IR, J], w: Path => WriteLike[O, IW]): Format[IR, IW, O] =
-    format(subR, Write.zero[O])
+  def format[JJ, J, O](subF: => Format[JJ, J, O])(implicit r: Path => RuleLike[IR, JJ], w: Path => WriteLike[J, IW]): Format[IR, IW, O] =
+    format(subF, subF)
+
+  // def format[J, O](subR: => RuleLike[J, O])(implicit r: Path => RuleLike[IR, J], w: Path => WriteLike[O, IW]): Format[IR, IW, O] =
+  //   format(subR, Write.zero[O])
 
   // def format[JJ, O](subW: => WriteLike[O, JJ])(implicit r: Path => RuleLike[I, O], w: Path => WriteLike[JJ, I]): Format[I, O] =
   //   format(Rule.zero[O], subW)

--- a/validation-form/src/test/scala/play/api/data/mapping/forms/FormatSpec.scala
+++ b/validation-form/src/test/scala/play/api/data/mapping/forms/FormatSpec.scala
@@ -264,8 +264,8 @@ object FormatSpec extends Specification {
 			import Writes._
 
 			val f = Formatting[UrlFormEncoded, UrlFormEncoded] { __ =>
-        ((__ \ "firstname").format(notEmpty) ~
-         (__ \ "lastname").format(notEmpty)).tupled
+        ((__ \ "firstname").format(notEmpty, Write.zero[String]) ~
+         (__ \ "lastname").format(notEmpty, Write.zero[String])).tupled
       }
 
 			val valid = Map(
@@ -300,7 +300,7 @@ object FormatSpec extends Specification {
 
       Formatting[UrlFormEncoded, UrlFormEncoded] { __ => (__ \ "firstname").format[Seq[String]] }.validate(valid) mustEqual(Success(Seq("Julien")))
       Formatting[UrlFormEncoded, UrlFormEncoded] { __ => (__ \ "foobar").format[Seq[String]] }.validate(valid) mustEqual(Success(Seq()))
-      Formatting[UrlFormEncoded, UrlFormEncoded] { __ => (__ \ "foobar").format(isNotEmpty[Seq[Int]]) }.validate(valid) mustEqual(Failure(Seq(Path \ "foobar" -> Seq(ValidationError("error.notEmpty")))))
+      Formatting[UrlFormEncoded, UrlFormEncoded] { __ => (__ \ "foobar").format(isNotEmpty[Seq[Int]], Write.zero[Seq[Int]]) }.validate(valid) mustEqual(Failure(Seq(Path \ "foobar" -> Seq(ValidationError("error.notEmpty")))))
     }
 
     "format recursive" in {

--- a/validation-json4s/src/test/scala/play/api/data/validation/json/FormatSpec.scala
+++ b/validation-json4s/src/test/scala/play/api/data/validation/json/FormatSpec.scala
@@ -264,8 +264,8 @@ object FormatSpec extends Specification {
 			import Writes._
 
 			val f = Formatting[JValue, JObject] { __ =>
-        ((__ \ "firstname").format(notEmpty) ~
-         (__ \ "lastname").format(notEmpty)).tupled
+        ((__ \ "firstname").format(notEmpty, Write.zero[String]) ~
+         (__ \ "lastname").format(notEmpty, Write.zero[String])).tupled
       }
 
 			val valid = JObject(
@@ -300,7 +300,7 @@ object FormatSpec extends Specification {
 
       Formatting[JValue, JObject] { __ => (__ \ "firstname").format[Seq[String]] }.validate(valid) mustEqual(Success(Seq("Julien")))
       Formatting[JValue, JObject] { __ => (__ \ "foobar").format[Seq[String]] }.validate(valid) mustEqual(Success(Seq()))
-      Formatting[JValue, JObject] { __ => (__ \ "foobar").format(isNotEmpty[Seq[Int]]) }.validate(valid) mustEqual(Failure(Seq(Path \ "foobar" -> Seq(ValidationError("error.notEmpty")))))
+      Formatting[JValue, JObject] { __ => (__ \ "foobar").format(isNotEmpty[Seq[Int]], Write.zero[Seq[Int]]) }.validate(valid) mustEqual(Failure(Seq(Path \ "foobar" -> Seq(ValidationError("error.notEmpty")))))
     }
 
     "format recursive" in {


### PR DESCRIPTION
I found it quite confusing that we have to write `(__ \ "path").read(subR)`, `(__ \ "path").write(subW)` but `(__ \ "path").format(subF)`. The overloading on the current definition of `format` is quite error prone, because `(__ \ "path").format(subF)` compiles, but `subF` is used as a Rule.