### PR TITLE
Make Format covariant in the write type

### DIFF
--- a/validation-core/src/main/scala/play/api/data/mapping/Format.scala
+++ b/validation-core/src/main/scala/play/api/data/mapping/Format.scala
@@ -4,7 +4,7 @@ import scala.annotation.implicitNotFound
 import scala.language.implicitConversions
 
 @implicitNotFound("No Format found for types ${IR},${IW}, ${O}. Try to implement an implicit Format[${IR}, ${IW}, ${O}].")
-trait Format[IR, IW, O] extends RuleLike[IR, O] with WriteLike[O, IW]
+trait Format[IR, +IW, O] extends RuleLike[IR, O] with WriteLike[O, IW]
 
 /**
  * Default formatters.

--- a/validation-json/src/test/scala/play/api/data/validation/json/FormatSpec.scala
+++ b/validation-json/src/test/scala/play/api/data/validation/json/FormatSpec.scala
@@ -383,6 +383,20 @@ object FormatSpec extends Specification {
 			win.writes(luigi) mustEqual(m2)
 		}
 
+    "be covarianace in the write type" in {
+      trait Animal
+      trait Cat extends Animal
+      case object MyCat extends Cat
+      
+      val f1: Format[Animal, Cat, Unit] = Format(Rule(_ => Success(())), Write(_ => MyCat))
+      val f2: Format[Animal, Animal, Unit] = f1
+      
+      // Note that we can achieve the above without covarianace on Format IW as follows:
+      val f3: Format[Animal, Animal, Unit] = Format(Rule.toRule(f1), Write(f1.writes))
+      
+      f1.writes(()) mustEqual f2.writes(())
+      f1.validate(MyCat) mustEqual f2.validate(MyCat)
+    }
 	}
 
 }


### PR DESCRIPTION
The `Format(Rule.toRule(f1), Write(f1.writes))` construct in the test shows that we can do the same with the current `Format` definition by using the same using covarianace on `Write`.

Related to #16?