### PR TITLE
Play 2.5.1 - 1.2.1 version

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -12,8 +12,8 @@ object Resolvers {
 
 object BuildSettings {
   val org = "io.github.jto"
-  val buildVersion = "1.1"
-  val playVersion = "2.4.1"
+  val buildVersion = "1.2.1"
+  val playVersion = "2.5.1"
   val paradiseVersion = "2.0.1"
 
   val scalaVersions = Seq(

--- a/validation-core/src/main/scala/play/api/data/mapping/Rule.scala
+++ b/validation-core/src/main/scala/play/api/data/mapping/Rule.scala
@@ -154,7 +154,7 @@ object Rule {
 
   // XXX: Helps the compiler a bit
   import play.api.libs.functional.syntax._
-  implicit def cba[I] = functionalCanBuildApplicative[({ type λ[O] = Rule[I, O] })#λ]
+  implicit def cba[I] = FunctionalCanBuild.functionalCanBuildApplicative[({ type λ[O] = Rule[I, O] })#λ]
   implicit def fbo[I, O] = toFunctionalBuilderOps[({ type λ[O] = Rule[I, O] })#λ, O] _
   implicit def ao[I, O] = toApplicativeOps[({ type λ[O] = Rule[I, O] })#λ, O] _
   implicit def f[I, O] = toFunctorOps[({ type λ[O] = Rule[I, O] })#λ, O] _

--- a/validation-core/src/main/scala/play/api/data/mapping/Validation.scala
+++ b/validation-core/src/main/scala/play/api/data/mapping/Validation.scala
@@ -235,7 +235,7 @@ object Validation {
 
   // XXX: Helps the compiler a bit
   import play.api.libs.functional.syntax._
-  implicit def cba[E] = functionalCanBuildApplicative[({ type λ[A] = Validation[E, A] })#λ]
+  implicit def cba[E] = FunctionalCanBuild.functionalCanBuildApplicative[({ type λ[A] = Validation[E, A] })#λ]
   implicit def validationFbo[I, O] = toFunctionalBuilderOps[({ type λ[O] = Validation[I, O] })#λ, O] _
 }
 


### PR DESCRIPTION
Added play 2.5 to dependencies and fixed compile errors.
Trying to run 1.1.x with play 2.5 results in NoSuchMethodError
