### PR TITLE
Add support for native json validation (jsjson)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -16,7 +16,7 @@ val scalaXmlVersion = "1.0.5"
 
 lazy val root = aggregate("validation", validationJVM, validationJS).in(file("."))
 lazy val validationJVM = aggregate("validationJVM", coreJVM, formJVM, delimitedJVM, json4sJVM, `validation-playjson`, `validation-xml`)
-lazy val validationJS = aggregate("validationJS", coreJS, formJS, delimitedJS, json4sJS)
+lazy val validationJS = aggregate("validationJS", coreJS, formJS, delimitedJS, json4sJS, `validation-jsjson`)
 
 lazy val `validation-core` = crossProject
   .crossType(CrossType.Pure)
@@ -67,6 +67,11 @@ lazy val `validation-xml` = project
   .settings(libraryDependencies +=
     "org.scala-lang.modules" %% "scala-xml" % scalaXmlVersion)
   .dependsOn(coreJVM)
+
+lazy val `validation-jsjson` = project
+  .enablePlugins(ScalaJSPlugin)
+  .settings(validationSettings: _*)
+  .dependsOn(coreJS)
 
 lazy val `validation-docs` = project
   .settings(validationSettings: _*)

--- a/validation-jsjson/src/main/scala/Rules.scala
+++ b/validation-jsjson/src/main/scala/Rules.scala
@@ -1,0 +1,143 @@
+package jto.validation
+package jsjson
+
+import scala.scalajs.js
+import scala.util.Try
+
+object Rules extends DefaultRules[js.Dynamic] {
+  private def jsonAs[T](
+      f: PartialFunction[js.Any, Validated[Seq[ValidationError], T]])(
+      msg: String, args: Any*) =
+    Rule.fromMapping[js.Dynamic, T](f.orElse {
+      case j => Invalid(Seq(ValidationError(msg, args: _*)))
+    })
+
+  implicit def stringR =
+    jsonAs[String] {
+      case v if (v: Any).isInstanceOf[String] => Valid(v.asInstanceOf[String])
+    }("error.invalid", "String")
+
+  implicit def booleanR =
+    jsonAs[Boolean] {
+      case v if v.isInstanceOf[Boolean] => Valid(v.asInstanceOf[Boolean])
+    }("error.invalid", "Boolean")
+
+  implicit def intR =
+    jsonAs[Int] {
+      case v if v.isInstanceOf[Int] => Valid(v.asInstanceOf[Int])
+    }("error.number", "Int")
+
+  implicit def shortR =
+    jsonAs[Short] {
+      case v if v.isInstanceOf[Short] => Valid(v.asInstanceOf[Short])
+    }("error.number", "Short")
+
+  implicit def longR =
+    jsonAs[Long] {
+      // Long are *opaque*, see http://www.scala-js.org/doc/semantics.html
+      case v if js.typeOf(v) == "number" && Try(v.toString.toLong).isSuccess =>
+        Valid(v.toString.toLong)
+    }("error.number", "Long")
+
+  implicit def jsObjectR =
+    jsonAs[js.Dictionary[js.Dynamic]] {
+      case v
+          if v != null && js.typeOf(v) == "object" && !js.Array.isArray(v) =>
+        Valid(v.asInstanceOf[js.Dictionary[js.Dynamic]])
+    }("error.invalid", "Object")
+
+  implicit def jsArrayR[A] =
+    jsonAs[js.Array[A]] {
+      case v: js.Array[_] => Valid(v.asInstanceOf[js.Array[A]])
+    }("error.invalid", "Array")
+
+  implicit def floatR =
+    jsonAs[Float] {
+      case v if v.isInstanceOf[Float] => Valid(v.asInstanceOf[Float])
+    }("error.number", "Float")
+
+  implicit def doubleR =
+    jsonAs[Double] {
+      case v if v.isInstanceOf[Double] => Valid(v.asInstanceOf[Double])
+    }("error.number", "Double")
+
+  implicit def bigDecimal =
+    jsonAs[BigDecimal] {
+      case v if Try(BigDecimal(v.toString)).isSuccess =>
+        Valid(BigDecimal(v.toString))
+    }("error.number", "BigDecimal")
+
+  import java.{math => jm}
+  implicit def javaBigDecimal =
+    jsonAs[jm.BigDecimal] {
+      case v if Try(new jm.BigDecimal(v.toString)).isSuccess =>
+        Valid(new jm.BigDecimal(v.toString))
+    }("error.number", "BigDecimal")
+
+  implicit val jsNullR = jsonAs[Null] {
+    case v if v == null => Valid(null)
+  }("error.invalid", "null")
+
+  implicit def ooo[O](
+      p: Path)(implicit pick: Path => RuleLike[js.Dynamic, js.Dynamic],
+               coerce: RuleLike[js.Dynamic, O]): Rule[js.Dynamic, Option[O]] =
+    optionR(Rule.zero[O])(pick, coerce)(p)
+
+  def optionR[J, O](
+      r: => RuleLike[J, O], noneValues: RuleLike[js.Dynamic, js.Dynamic]*)(
+      implicit pick: Path => RuleLike[js.Dynamic, js.Dynamic],
+      coerce: RuleLike[js.Dynamic, J]): Path => Rule[js.Dynamic, Option[O]] =
+    super.opt[J, O](r, (jsNullR.map(n => n: js.Dynamic) +: noneValues): _*)
+
+  implicit def mapR[O](
+      implicit r: RuleLike[js.Dynamic, O]): Rule[js.Dynamic, Map[String, O]] =
+    super.mapR[js.Dynamic, O](r, jsObjectR.map(_.toSeq))
+
+  implicit def jsDictToDyn[O](
+      implicit r: RuleLike[js.Dictionary[js.Dynamic], O])
+    : Rule[js.Dynamic, O] =
+    jsObjectR.andThen(r)
+
+  implicit def pickInJson[II <: js.Dynamic, O](p: Path)(
+      implicit r: RuleLike[js.Dynamic, O]): Rule[II, O] = {
+    def search(path: Path, json: js.Dynamic): Option[js.Dynamic] =
+      path.path match {
+        case KeyPathNode(k) :: t =>
+          jsObjectR.validate(json).toOption.flatMap {
+            obj: js.Dictionary[js.Dynamic] =>
+              obj.find(_._1 == k).flatMap(kv => search(Path(t), kv._2))
+          }
+
+        case IdxPathNode(i) :: t =>
+          jsArrayR.validate(json).toOption.flatMap {
+            array: js.Array[js.Dynamic] =>
+              array.lift(i).flatMap(j => search(Path(t), j))
+          }
+
+        case Nil => Some(json)
+      }
+
+    Rule[II, js.Dynamic] { json =>
+      search(p, json) match {
+        case None =>
+          Invalid(Seq(Path -> Seq(ValidationError("error.required"))))
+        case Some(js) => Valid(js)
+      }
+    }.andThen(r)
+  }
+
+  // XXX: a bit of boilerplate
+  private def pickInS[T](
+      implicit r: RuleLike[Seq[js.Dynamic], T]): Rule[js.Dynamic, T] =
+    jsArrayR[js.Dynamic].map(fs => Seq(fs: _*)).andThen(r)
+  implicit def pickSeq[O](implicit r: RuleLike[js.Dynamic, O]) =
+    pickInS(seqR[js.Dynamic, O])
+  implicit def pickSet[O](implicit r: RuleLike[js.Dynamic, O]) =
+    pickInS(setR[js.Dynamic, O])
+  implicit def pickList[O](implicit r: RuleLike[js.Dynamic, O]) =
+    pickInS(listR[js.Dynamic, O])
+  implicit def pickArray[O : scala.reflect.ClassTag](
+      implicit r: RuleLike[js.Dynamic, O]) = pickInS(arrayR[js.Dynamic, O])
+  implicit def pickTraversable[O](implicit r: RuleLike[js.Dynamic, O]) =
+    pickInS(traversableR[js.Dynamic, O])
+}

--- a/validation-jsjson/src/main/scala/Writes.scala
+++ b/validation-jsjson/src/main/scala/Writes.scala
@@ -1,0 +1,103 @@
+package jto.validation
+package jsjson
+
+import cats.Monoid
+import scala.scalajs.js
+
+trait DefaultMonoids {
+  implicit def jsonMonoid = new Monoid[js.Dynamic] {
+    // TODO: Should this be a deepMerge?
+    def combine(a1: js.Dynamic, a2: js.Dynamic): js.Dynamic =
+      js.Dictionary[js.Dynamic](
+            (a1.asInstanceOf[js.Dictionary[js.Dynamic]] ++ a2
+                  .asInstanceOf[js.Dictionary[js.Dynamic]]).toSeq: _*
+        )
+        .asInstanceOf[js.Dynamic]
+
+    def empty: js.Dynamic =
+      js.Dynamic.literal()
+  }
+}
+
+object Writes
+    extends DefaultWrites with DefaultMonoids with GenericWrites[js.Dynamic] {
+  private def writeObj(j: js.Dynamic, n: PathNode): js.Dynamic = n match {
+    case IdxPathNode(_) => js.Array(j).asInstanceOf[js.Dynamic]
+    case KeyPathNode(key) => js.Dynamic.literal(key -> j)
+  }
+
+  implicit val validationErrorW = Write[ValidationError, js.Dynamic] { err =>
+    js.Dynamic.literal(
+        "msg" -> err.message,
+        "args" -> err.args.foldLeft(js.Array(js.Array[Object]())) {
+          (arr, arg) =>
+            js.Array(arr :+ arg.toString)
+        })
+  }
+
+  implicit def errorsW(
+      implicit wErrs: WriteLike[Seq[ValidationError], js.Dynamic]) =
+    Write[(Path, Seq[ValidationError]), js.Dynamic] {
+      case (p, errs) =>
+        js.Dynamic.literal(p.toString -> wErrs.writes(errs))
+    }
+
+  implicit def failureW(
+      implicit w: WriteLike[(Path, Seq[ValidationError]), js.Dynamic]) =
+    Write[Invalid[Seq[(Path, Seq[ValidationError])]], js.Dynamic] {
+      case Invalid(errs) =>
+        errs.map(w.writes).reduce(jsonMonoid.combine)
+    }
+
+  implicit val stringW = Write[String, js.Dynamic](_.asInstanceOf[js.Dynamic])
+
+  implicit val intW = Write[Int, js.Dynamic](_.asInstanceOf[js.Dynamic])
+  implicit val shortW = Write[Short, js.Dynamic](_.asInstanceOf[js.Dynamic])
+  implicit val floatW = Write[Float, js.Dynamic](_.asInstanceOf[js.Dynamic])
+  implicit val doubleW = Write[Double, js.Dynamic](_.asInstanceOf[js.Dynamic])
+  implicit val bigDecimalW =
+    Write[BigDecimal, js.Dynamic](_.toString.asInstanceOf[js.Dynamic])
+  // Long are *opaque*, see http://www.scala-js.org/doc/semantics.html
+  implicit val longW = Write[Long, js.Dynamic] { l =>
+    (l: js.Any).asInstanceOf[js.Dynamic]
+  }
+
+  implicit def booleanW =
+    Write[Boolean, js.Dynamic](_.asInstanceOf[js.Dynamic])
+
+  implicit def seqToJsArray[I](
+      implicit w: WriteLike[I, js.Dynamic]): Write[Seq[I], js.Dynamic] =
+    Write(ss => js.Array(ss.map(w.writes _): _*).asInstanceOf[js.Dynamic])
+
+  def optionW[I, J](
+      r: => WriteLike[I, J])(implicit w: Path => WriteLike[J, js.Dynamic])
+    : Path => Write[Option[I], js.Dynamic] =
+    super.optionW[I, J, js.Dynamic](r, js.Dynamic.literal())
+
+  implicit def optionW[I](implicit w: Path => WriteLike[I, js.Dynamic])
+    : Path => Write[Option[I], js.Dynamic] =
+    optionW(Write.zero[I])
+
+  implicit def mapW[I](implicit w: WriteLike[I, js.Dynamic]) =
+    Write[Map[String, I], js.Dynamic] { m =>
+      // Can't use js.Dynamic.literal here because of SI-9308.
+      js.Dictionary[js.Dynamic](m.mapValues(w.writes).toSeq: _*)
+        .asInstanceOf[js.Dynamic]
+    }
+
+  implicit def writeJson[I](path: Path)(
+      implicit w: WriteLike[I, js.Dynamic]): Write[I, js.Dynamic] = Write {
+    i =>
+      path match {
+        case Path(KeyPathNode(x) :: _) \: _ =>
+          val ps = path.path.reverse
+          val h = ps.head
+          val o = writeObj(w.writes(i), h)
+          ps.tail.foldLeft(o)(writeObj).asInstanceOf[js.Dynamic]
+        case Path(Nil) =>
+          w.writes(i).asInstanceOf[js.Dynamic]
+        case _ =>
+          throw new RuntimeException(s"path $path is not a path of JsObject") // XXX: should be a compile time error
+      }
+  }
+}

--- a/validation-jsjson/src/test/scala/FormatSpec.scala
+++ b/validation-jsjson/src/test/scala/FormatSpec.scala
@@ -1,0 +1,441 @@
+import jto.validation._
+import jto.validation.jsjson.Rules._
+import jto.validation.jsjson.Writes._
+import org.scalatest._
+import scala.scalajs.js
+import Function.unlift
+
+class FormatSpec extends WordSpec with Matchers with JsAnyEquality {
+
+  case class User(id: Long, name: String)
+  val luigi = User(1, "Luigi")
+
+  "Format" should {
+
+    "serialize and deserialize primitives" in {
+      val f = Formatting[js.Dynamic, js.Dynamic] { __ =>
+        (__ \ "id").format[Long]
+      }
+
+      val m = js.Dynamic.literal("id" -> 1L)
+
+      f.writes(1L) shouldBe m
+      f.validate(m) shouldBe (Valid(1L))
+
+      (Path \ "id").from[js.Dynamic](f).validate(js.Dynamic.literal()) shouldBe
+      (Invalid(Seq(Path \ "id" -> Seq(ValidationError("error.required")))))
+    }
+
+    "serialize and deserialize String" in {
+      val f = Formatting[js.Dynamic, js.Dynamic] { __ =>
+        (__ \ "id").format[String]
+      }
+
+      val m = js.Dynamic.literal("id" -> "CAFEBABE")
+
+      f.writes("CAFEBABE") shouldBe m
+      f.validate(m) shouldBe (Valid("CAFEBABE"))
+
+      (Path \ "id").from[js.Dynamic](f).validate(js.Dynamic.literal()) shouldBe
+      (Invalid(Seq(Path \ "id" -> Seq(ValidationError("error.required")))))
+    }
+
+    "serialize and deserialize Seq[String]" in {
+      val f = Formatting[js.Dynamic, js.Dynamic] { __ =>
+        (__ \ "ids").format[Seq[String]]
+      }
+      val m = js.Dynamic.literal("ids" -> js.Array("CAFEBABE", "FOOBAR"))
+
+      f.validate(m) shouldBe (Valid(Seq("CAFEBABE", "FOOBAR")))
+      f.writes(Seq("CAFEBABE", "FOOBAR")) shouldBe m
+    }
+
+    "serialize and deserialize User case class" in {
+      implicit val userF = Formatting[js.Dynamic, js.Dynamic] { __ =>
+        ((__ \ "id").format[Long] ~ (__ \ "name").format[String])(
+            User.apply, unlift(User.unapply))
+      }
+
+      val m = js.Dynamic.literal("id" -> 1L, "name" -> "Luigi")
+      userF.validate(m) shouldBe (Valid(luigi))
+    }
+
+    "support primitives types" when {
+      "Int" in {
+        Formatting[js.Dynamic, js.Dynamic] { __ =>
+          (__ \ "n").format[Int]
+        }.validate(js.Dynamic.literal("n" -> 4)) shouldBe (Valid(4))
+        Formatting[js.Dynamic, js.Dynamic] { __ =>
+          (__ \ "n").format[Int]
+        }.validate(js.Dynamic.literal("n" -> "foo")) shouldBe
+        (Invalid(Seq(Path \ "n" -> Seq(
+                        ValidationError("error.number", "Int")))))
+        Formatting[js.Dynamic, js.Dynamic] { __ =>
+          (__ \ "n").format[Int]
+        }.validate(js.Dynamic.literal("n" -> 4.5)) shouldBe
+        (Invalid(Seq(Path \ "n" -> Seq(
+                        ValidationError("error.number", "Int")))))
+        Formatting[js.Dynamic, js.Dynamic] { __ =>
+          (__ \ "n" \ "o").format[Int]
+        }.validate(js.Dynamic.literal("n" -> js.Dynamic.literal("o" -> 4))) shouldBe
+        (Valid(4))
+        Formatting[js.Dynamic, js.Dynamic] { __ =>
+          (__ \ "n" \ "o").format[Int]
+        }.validate(js.Dynamic.literal("n" -> js.Dynamic.literal("o" -> "foo"))) shouldBe
+        (Invalid(Seq(Path \ "n" \ "o" -> Seq(
+                        ValidationError("error.number", "Int")))))
+
+        Formatting[js.Dynamic, js.Dynamic] { __ =>
+          (__ \ "n" \ "o" \ "p").format[Int]
+        }.validate(js.Dynamic.literal("n" -> js.Dynamic.literal(
+                    "o" -> js.Dynamic.literal("p" -> 4)))) shouldBe (Valid(4))
+        Formatting[js.Dynamic, js.Dynamic] { __ =>
+          (__ \ "n" \ "o" \ "p").format[Int]
+        }.validate(js.Dynamic.literal("n" -> js.Dynamic
+                  .literal("o" -> js.Dynamic.literal("p" -> "foo")))) shouldBe
+        (Invalid(Seq(Path \ "n" \ "o" \ "p" -> Seq(
+                        ValidationError("error.number", "Int")))))
+
+        val errPath = Path \ "foo"
+        val error =
+          Invalid(Seq(errPath -> Seq(ValidationError("error.required"))))
+        Formatting[js.Dynamic, js.Dynamic] { __ =>
+          (__ \ "foo").format[Int]
+        }.validate(js.Dynamic.literal("n" -> 4)) shouldBe (error)
+      }
+
+      "Short" in {
+        Formatting[js.Dynamic, js.Dynamic] { __ =>
+          (__ \ "n").format[Short]
+        }.validate(js.Dynamic.literal("n" -> 4)) shouldBe (Valid(4))
+        Formatting[js.Dynamic, js.Dynamic] { __ =>
+          (__ \ "n").format[Short]
+        }.validate(js.Dynamic.literal("n" -> "foo")) shouldBe
+        (Invalid(Seq(Path \ "n" -> Seq(
+                        ValidationError("error.number", "Short")))))
+        Formatting[js.Dynamic, js.Dynamic] { __ =>
+          (__ \ "n").format[Short]
+        }.validate(js.Dynamic.literal("n" -> 4.5)) shouldBe
+        (Invalid(Seq(Path \ "n" -> Seq(
+                        ValidationError("error.number", "Short")))))
+      }
+
+      "Long" in {
+        Formatting[js.Dynamic, js.Dynamic] { __ =>
+          (__ \ "n").format[Long]
+        }.validate(js.Dynamic.literal("n" -> 4)) shouldBe (Valid(4))
+        Formatting[js.Dynamic, js.Dynamic] { __ =>
+          (__ \ "n").format[Long]
+        }.validate(js.Dynamic.literal("n" -> "foo")) shouldBe
+        (Invalid(Seq(Path \ "n" -> Seq(
+                        ValidationError("error.number", "Long")))))
+        Formatting[js.Dynamic, js.Dynamic] { __ =>
+          (__ \ "n").format[Long]
+        }.validate(js.Dynamic.literal("n" -> 4.5)) shouldBe
+        (Invalid(Seq(Path \ "n" -> Seq(
+                        ValidationError("error.number", "Long")))))
+      }
+
+      "Float" in {
+        Formatting[js.Dynamic, js.Dynamic] { __ =>
+          (__ \ "n").format[Float]
+        }.validate(js.Dynamic.literal("n" -> 4)) shouldBe (Valid(4))
+        Formatting[js.Dynamic, js.Dynamic] { __ =>
+          (__ \ "n").format[Float]
+        }.validate(js.Dynamic.literal("n" -> "foo")) shouldBe
+        (Invalid(Seq(Path \ "n" -> Seq(
+                        ValidationError("error.number", "Float")))))
+        Formatting[js.Dynamic, js.Dynamic] { __ =>
+          (__ \ "n").format[Float]
+        }.validate(js.Dynamic.literal("n" -> 4.5)) shouldBe (Valid(4.5F))
+      }
+
+      "Double" in {
+        Formatting[js.Dynamic, js.Dynamic] { __ =>
+          (__ \ "n").format[Double]
+        }.validate(js.Dynamic.literal("n" -> 4)) shouldBe (Valid(4))
+        Formatting[js.Dynamic, js.Dynamic] { __ =>
+          (__ \ "n").format[Double]
+        }.validate(js.Dynamic.literal("n" -> "foo")) shouldBe
+        (Invalid(Seq(Path \ "n" -> Seq(
+                        ValidationError("error.number", "Double")))))
+        Formatting[js.Dynamic, js.Dynamic] { __ =>
+          (__ \ "n").format[Double]
+        }.validate(js.Dynamic.literal("n" -> 4.5)) shouldBe (Valid(4.5))
+      }
+
+      "scala BigDecimal" in {
+        Formatting[js.Dynamic, js.Dynamic] { __ =>
+          (__ \ "n").format[BigDecimal]
+        }.validate(js.Dynamic.literal("n" -> 4)) shouldBe
+        (Valid(BigDecimal(4)))
+        Formatting[js.Dynamic, js.Dynamic] { __ =>
+          (__ \ "n").format[BigDecimal]
+        }.validate(js.Dynamic.literal("n" -> "foo")) shouldBe
+        (Invalid(Seq(Path \ "n" -> Seq(
+                        ValidationError("error.number", "BigDecimal")))))
+        Formatting[js.Dynamic, js.Dynamic] { __ =>
+          (__ \ "n").format[BigDecimal]
+        }.validate(js.Dynamic.literal("n" -> 4.5)) shouldBe
+        (Valid(BigDecimal(4.5)))
+      }
+
+      "Boolean" in {
+        Formatting[js.Dynamic, js.Dynamic] { __ =>
+          (__ \ "n").format[Boolean]
+        }.validate(js.Dynamic.literal("n" -> true)) shouldBe (Valid(true))
+        Formatting[js.Dynamic, js.Dynamic] { __ =>
+          (__ \ "n").format[Boolean]
+        }.validate(js.Dynamic.literal("n" -> "foo")) shouldBe
+        (Invalid(Seq(Path \ "n" -> Seq(
+                        ValidationError("error.invalid", "Boolean")))))
+      }
+
+      "String" in {
+        Formatting[js.Dynamic, js.Dynamic] { __ =>
+          (__ \ "n").format[String]
+        }.validate(js.Dynamic.literal("n" -> "foo")) shouldBe (Valid("foo"))
+        Formatting[js.Dynamic, js.Dynamic] { __ =>
+          (__ \ "o").format[String]
+        }.validate(js.Dynamic.literal("o.n" -> "foo")) shouldBe
+        (Invalid(Seq(Path \ "o" -> Seq(ValidationError("error.required")))))
+      }
+
+      "Option" in {
+        Formatting[js.Dynamic, js.Dynamic] { __ =>
+          (__ \ "n").format[Option[Boolean]]
+        }.validate(js.Dynamic.literal("n" -> true)) shouldBe
+        (Valid(Some(true)))
+        Formatting[js.Dynamic, js.Dynamic] { __ =>
+          (__ \ "n").format[Option[Boolean]]
+        }.validate(js.Dynamic.literal()) shouldBe (Valid(None))
+        Formatting[js.Dynamic, js.Dynamic] { __ =>
+          (__ \ "n").format[Option[Boolean]]
+        }.validate(js.Dynamic.literal("foo" -> "bar")) shouldBe (Valid(None))
+        Formatting[js.Dynamic, js.Dynamic] { __ =>
+          (__ \ "n").format[Option[Boolean]]
+        }.validate(js.Dynamic.literal("n" -> "bar")) shouldBe
+        (Invalid(Seq(Path \ "n" -> Seq(
+                        ValidationError("error.invalid", "Boolean")))))
+      }
+
+      "Map[String, Seq[V]]" in {
+        Formatting[js.Dynamic, js.Dynamic] { __ =>
+          (__ \ "n").format[Map[String, Seq[String]]]
+        }.validate(js.Dynamic.literal(
+                "n" -> js.Dynamic.literal("foo" -> js.Array("bar")))) shouldBe
+        (Valid(Map("foo" -> Seq("bar"))))
+        Formatting[js.Dynamic, js.Dynamic] { __ =>
+          (__ \ "n").format[Map[String, Seq[Int]]]
+        }.validate(js.Dynamic.literal("n" -> js.Dynamic.literal(
+                    "foo" -> js.Array(4), "bar" -> js.Array(5)))) shouldBe
+        (Valid(Map("foo" -> Seq(4), "bar" -> Seq(5))))
+        Formatting[js.Dynamic, js.Dynamic] { __ =>
+          (__ \ "x").format[Map[String, Int]]
+        }.validate(js.Dynamic.literal("n" -> js.Dynamic.literal(
+                    "foo" -> 4, "bar" -> "frack"))) shouldBe
+        (Invalid(Seq(Path \ "x" -> Seq(ValidationError("error.required")))))
+        Formatting[js.Dynamic, js.Dynamic] { __ =>
+          (__ \ "n").format[Map[String, Seq[Int]]]
+        }.validate(js.Dynamic.literal("n" -> js.Dynamic.literal(
+                    "foo" -> js.Array(4),
+                    "bar" -> js.Array("frack")))) shouldBe
+        (Invalid(Seq(Path \ "n" \ "bar" \ 0 -> Seq(
+                        ValidationError("error.number", "Int")))))
+      }
+
+      "Traversable" in {
+        Formatting[js.Dynamic, js.Dynamic] { __ =>
+          (__ \ "n").format[Traversable[String]]
+        }.validate(js.Dynamic.literal("n" -> js.Array("foo")))
+          .toOption
+          .get
+          .toSeq shouldBe (Seq("foo"))
+        Formatting[js.Dynamic, js.Dynamic] { __ =>
+          (__ \ "n").format[Traversable[Int]]
+        }.validate(js.Dynamic.literal("n" -> js.Array(1, 2, 3)))
+          .toOption
+          .get
+          .toSeq shouldBe (Seq(1, 2, 3))
+        Formatting[js.Dynamic, js.Dynamic] { __ =>
+          (__ \ "n").format[Traversable[Int]]
+        }.validate(js.Dynamic.literal("n" -> js.Array("1", "paf"))) shouldBe
+        (Invalid(Seq(
+                    Path \ "n" \ 0 -> Seq(
+                        ValidationError("error.number", "Int")),
+                    Path \ "n" \ 1 -> Seq(
+                        ValidationError("error.number", "Int"))
+                )))
+      }
+
+      "Array" in {
+        Formatting[js.Dynamic, js.Dynamic] { __ =>
+          (__ \ "n").format[Array[String]]
+        }.validate(js.Dynamic.literal("n" -> js.Array("foo")))
+          .toOption
+          .get
+          .toSeq shouldBe (Seq("foo"))
+        Formatting[js.Dynamic, js.Dynamic] { __ =>
+          (__ \ "n").format[Array[Int]]
+        }.validate(js.Dynamic.literal("n" -> js.Array(1, 2, 3)))
+          .toOption
+          .get
+          .toSeq shouldBe (Seq(1, 2, 3))
+        Formatting[js.Dynamic, js.Dynamic] { __ =>
+          (__ \ "n").format[Array[Int]]
+        }.validate(js.Dynamic.literal("n" -> js.Array("1", "paf"))) shouldBe
+        (Invalid(Seq(
+                    Path \ "n" \ 0 -> Seq(
+                        ValidationError("error.number", "Int")),
+                    Path \ "n" \ 1 -> Seq(
+                        ValidationError("error.number", "Int"))
+                )))
+      }
+
+      "Seq" in {
+        Formatting[js.Dynamic, js.Dynamic] { __ =>
+          (__ \ "n").format[Seq[String]]
+        }.validate(js.Dynamic.literal("n" -> js.Array("foo"))).toOption.get shouldBe
+        (Seq("foo"))
+        Formatting[js.Dynamic, js.Dynamic] { __ =>
+          (__ \ "n").format[Seq[Int]]
+        }.validate(js.Dynamic.literal("n" -> js.Array(1, 2, 3))).toOption.get shouldBe
+        (Seq(1, 2, 3))
+        Formatting[js.Dynamic, js.Dynamic] { __ =>
+          (__ \ "n").format[Seq[Int]]
+        }.validate(js.Dynamic.literal("n" -> js.Array("1", "paf"))) shouldBe
+        (Invalid(Seq(
+                    Path \ "n" \ 0 -> Seq(
+                        ValidationError("error.number", "Int")),
+                    Path \ "n" \ 1 -> Seq(
+                        ValidationError("error.number", "Int"))
+                )))
+      }
+    }
+
+    "serialize and deserialize with validation" in {
+      val f = Formatting[js.Dynamic, js.Dynamic] { __ =>
+        ((__ \ "firstname").format(notEmpty) ~ (__ \ "lastname").format(
+                notEmpty)).tupled
+      }
+
+      val valid =
+        js.Dynamic.literal("firstname" -> "Julien", "lastname" -> "Tournay")
+
+      val invalid = js.Dynamic.literal("lastname" -> "Tournay")
+
+      val result = ("Julien", "Tournay")
+
+      f.writes(result) shouldBe (valid)
+      f.validate(valid) shouldBe (Valid(result))
+
+      f.validate(invalid) shouldBe
+      (Invalid(Seq((Path \ "firstname",
+                    Seq(ValidationError("error.required"))))))
+    }
+
+    "format seq" in {
+      val valid = js.Dynamic.literal(
+          "firstname" -> js.Array("Julien"),
+          "foobar" -> js.Array(),
+          "lastname" -> "Tournay",
+          "age" -> 27,
+          "information" -> js.Dynamic.literal(
+              "label" -> "Personal",
+              "email" -> "fakecontact@gmail.com",
+              "phones" -> js.Array("01.23.45.67.89", "98.76.54.32.10")))
+
+      def isNotEmpty[T <: Traversable[_]] = validateWith[T]("error.notEmpty") {
+        !_.isEmpty
+      }
+
+      Formatting[js.Dynamic, js.Dynamic] { __ =>
+        (__ \ "firstname").format[Seq[String]]
+      }.validate(valid) shouldBe (Valid(Seq("Julien")))
+      Formatting[js.Dynamic, js.Dynamic] { __ =>
+        (__ \ "foobar").format[Seq[String]]
+      }.validate(valid) shouldBe (Valid(Seq()))
+      Formatting[js.Dynamic, js.Dynamic] { __ =>
+        (__ \ "foobar").format(isNotEmpty[Seq[Int]])
+      }.validate(valid) shouldBe
+      (Invalid(Seq(Path \ "foobar" -> Seq(ValidationError("error.notEmpty")))))
+    }
+
+    "format recursive" when {
+      case class RecUser(name: String, friends: Seq[RecUser] = Nil)
+      val u = RecUser("bob", Seq(RecUser("tom")))
+
+      val m = js.Dynamic.literal(
+          "name" -> "bob",
+          "friends" -> js.Array(
+              js.Dynamic.literal("name" -> "tom", "friends" -> js.Array())))
+
+      case class User1(name: String, friend: Option[User1] = None)
+      val u1 = User1("bob", Some(User1("tom")))
+      val m1 = js.Dynamic.literal(
+          "name" -> "bob", "friend" -> js.Dynamic.literal("name" -> "tom"))
+
+      "using explicit notation" in {
+        lazy val w: Format[js.Dynamic, js.Dynamic, RecUser] =
+          Formatting[js.Dynamic, js.Dynamic] { __ =>
+            ((__ \ "name").format[String] ~ (__ \ "friends").format(
+                    seqR(w), seqW(w)))(RecUser.apply, unlift(RecUser.unapply))
+          }
+        w.validate(m) shouldBe Valid(u)
+        w.writes(u) shouldBe m
+
+        lazy val w3: Format[js.Dynamic, js.Dynamic, User1] =
+          Formatting[js.Dynamic, js.Dynamic] { __ =>
+            ((__ \ "name").format[String] ~ (__ \ "friend").format(
+                    optionR(w3),
+                    optionW(w3)))(User1.apply, unlift(User1.unapply))
+          }
+        w3.validate(m1) shouldBe Valid(u1)
+        w3.writes(u1) shouldBe m1
+      }
+
+      "using implicit notation" in {
+        implicit lazy val w: Format[js.Dynamic, js.Dynamic, RecUser] =
+          Formatting[js.Dynamic, js.Dynamic] { __ =>
+            ((__ \ "name").format[String] ~ (__ \ "friends")
+                  .format[Seq[RecUser]])(RecUser.apply,
+                                         unlift(RecUser.unapply))
+          }
+        w.validate(m) shouldBe Valid(u)
+        w.writes(u) shouldBe m
+
+        implicit lazy val w3: Format[js.Dynamic, js.Dynamic, User1] =
+          Formatting[js.Dynamic, js.Dynamic] { __ =>
+            ((__ \ "name").format[String] ~ (__ \ "friend")
+                  .format[Option[User1]])(User1.apply, unlift(User1.unapply))
+          }
+        w3.validate(m1) shouldBe Valid(u1)
+        w3.writes(u1) shouldBe m1
+      }
+    }
+
+    "work with Rule ans Write seamlessly" in {
+      implicit val userF = Formatting[js.Dynamic, js.Dynamic] { __ =>
+        ((__ \ "id").format[Long] ~ (__ \ "name").format[String])(
+            User.apply,
+            unlift(User.unapply))
+      }
+
+      val userJs = js.Dynamic.literal("id" -> 1L, "name" -> "Luigi")
+      userF.validate(userJs) shouldBe (Valid(luigi))
+      userF.writes(luigi) shouldBe (userJs)
+
+      val fin = From[js.Dynamic] { __ =>
+        (__ \ "user").read[User]
+      }
+
+      val m2 = js.Dynamic.literal("user" -> userJs)
+      fin.validate(m2) shouldBe (Valid(luigi))
+
+      val win = To[js.Dynamic] { __ =>
+        (__ \ "user").write[User]
+      }
+      win.writes(luigi) shouldBe (m2)
+    }
+  }
+}

--- a/validation-jsjson/src/test/scala/JsAnyEquality.scala
+++ b/validation-jsjson/src/test/scala/JsAnyEquality.scala
@@ -1,0 +1,10 @@
+import scala.scalajs.js
+import org.scalatest._
+
+trait JsAnyEquality {
+  this: Matchers =>
+  implicit class ShouldBeEqualAfterStringify(val dynamic: js.Any) {
+    def shouldBe(otherDynamic: js.Any): Assertion =
+      js.JSON.stringify(dynamic) shouldBe js.JSON.stringify(otherDynamic)
+  }
+}

--- a/validation-jsjson/src/test/scala/RulesSpec.scala
+++ b/validation-jsjson/src/test/scala/RulesSpec.scala
@@ -1,0 +1,673 @@
+import jto.validation._
+import jto.validation.jsjson._
+import jto.validation.jsjson.Rules._
+import org.scalatest._
+import scala.scalajs.js
+
+class RulesSpec extends WordSpec with Matchers {
+
+  "Json Rules" should {
+
+    val valid = js.Dynamic.literal(
+        "firstname" -> "Julien",
+        "lastname" -> "Tournay",
+        "age" -> 27,
+        "informations" -> js.Dynamic.literal(
+            "label" -> "Personal",
+            "email" -> "fakecontact@gmail.com",
+            "phones" -> js.Array("01.23.45.67.89", "98.76.54.32.10")))
+
+    val invalid = js.Dynamic.literal(
+        "firstname" -> "Julien",
+        "lastname" -> "Tournay",
+        "age" -> 27,
+        "informations" -> js.Dynamic.literal(
+            "label" -> "",
+            "email" -> "fakecontact@gmail.com",
+            "phones" -> js.Array("01.23.45.67.89", "98.76.54.32.10")))
+
+    "extract data" in {
+      (Path \ "firstname").read[js.Dynamic, String].validate(valid) shouldBe
+      (Valid("Julien"))
+      val errPath = Path \ "foo"
+      val error =
+        Invalid(Seq(errPath -> Seq(ValidationError("error.required"))))
+      errPath.read[js.Dynamic, String].validate(invalid) shouldBe (error)
+    }
+
+    "support checked" in {
+      val json = js.Dynamic.literal("issmth" -> true)
+      val p = Path \ "issmth"
+      p.from[js.Dynamic](checked).validate(json) shouldBe (Valid(true))
+      p.from[js.Dynamic](checked).validate(js.Dynamic.literal()) shouldBe
+      (Invalid(Seq(Path \ "issmth" -> Seq(ValidationError("error.required")))))
+      p.from[js.Dynamic](checked)
+        .validate(js.Dynamic.literal("issmth" -> false)) shouldBe
+      (Invalid(Seq(Path \ "issmth" -> Seq(
+                      ValidationError("error.equals", true)))))
+    }
+
+    "support all types of Json values" when {
+
+      "null" in {
+        (Path \ "n")
+          .read[js.Dynamic, Null]
+          .validate(js.Dynamic.literal("n" -> null)) shouldBe (Valid(null))
+        (Path \ "n")
+          .read[js.Dynamic, Null]
+          .validate(js.Dynamic.literal("n" -> "foo")) shouldBe
+        (Invalid(Seq(Path \ "n" -> Seq(
+                        ValidationError("error.invalid", "null")))))
+        (Path \ "n")
+          .read[js.Dynamic, Null]
+          .validate(js.Dynamic.literal("n" -> 4.5)) shouldBe
+        (Invalid(Seq(Path \ "n" -> Seq(
+                        ValidationError("error.invalid", "null")))))
+      }
+
+      "Int" in {
+        (Path \ "n")
+          .read[js.Dynamic, Int]
+          .validate(js.Dynamic.literal("n" -> 4)) shouldBe (Valid(4))
+        (Path \ "n")
+          .read[js.Dynamic, Int]
+          .validate(js.Dynamic.literal("n" -> "foo")) shouldBe
+        (Invalid(Seq(Path \ "n" -> Seq(
+                        ValidationError("error.number", "Int")))))
+        (Path \ "n")
+          .read[js.Dynamic, Int]
+          .validate(js.Dynamic.literal("n" -> 4.5)) shouldBe
+        (Invalid(Seq(Path \ "n" -> Seq(
+                        ValidationError("error.number", "Int")))))
+        (Path \ "n" \ "o")
+          .read[js.Dynamic, Int]
+          .validate(js.Dynamic.literal("n" -> js.Dynamic.literal("o" -> 4))) shouldBe
+        (Valid(4))
+        (Path \ "n" \ "o")
+          .read[js.Dynamic, Int]
+          .validate(js.Dynamic.literal(
+                  "n" -> js.Dynamic.literal("o" -> "foo"))) shouldBe
+        (Invalid(Seq(Path \ "n" \ "o" -> Seq(
+                        ValidationError("error.number", "Int")))))
+
+        (Path \ "n" \ "o" \ "p")
+          .read[js.Dynamic, Int]
+          .validate(js.Dynamic.literal("n" -> js.Dynamic.literal(
+                      "o" -> js.Dynamic.literal("p" -> 4)))) shouldBe
+        (Valid(4))
+        (Path \ "n" \ "o" \ "p")
+          .read[js.Dynamic, Int]
+          .validate(js.Dynamic.literal("n" -> js.Dynamic.literal(
+                      "o" -> js.Dynamic.literal("p" -> "foo")))) shouldBe
+        (Invalid(Seq(Path \ "n" \ "o" \ "p" -> Seq(
+                        ValidationError("error.number", "Int")))))
+
+        val errPath = Path \ "foo"
+        val error =
+          Invalid(Seq(errPath -> Seq(ValidationError("error.required"))))
+        errPath.read[js.Dynamic, Int].validate(js.Dynamic.literal("n" -> 4)) shouldBe
+        (error)
+      }
+
+      "Short" in {
+        (Path \ "n")
+          .read[js.Dynamic, Short]
+          .validate(js.Dynamic.literal("n" -> 4)) shouldBe (Valid(4))
+        (Path \ "n")
+          .read[js.Dynamic, Short]
+          .validate(js.Dynamic.literal("n" -> "foo")) shouldBe
+        (Invalid(Seq(Path \ "n" -> Seq(
+                        ValidationError("error.number", "Short")))))
+        (Path \ "n")
+          .read[js.Dynamic, Short]
+          .validate(js.Dynamic.literal("n" -> 4.5)) shouldBe
+        (Invalid(Seq(Path \ "n" -> Seq(
+                        ValidationError("error.number", "Short")))))
+      }
+
+      "Long" in {
+        (Path \ "n")
+          .read[js.Dynamic, Long]
+          .validate(js.Dynamic.literal("n" -> 4)) shouldBe (Valid(4))
+        (Path \ "n")
+          .read[js.Dynamic, Long]
+          .validate(js.Dynamic.literal("n" -> "foo")) shouldBe
+        (Invalid(Seq(Path \ "n" -> Seq(
+                        ValidationError("error.number", "Long")))))
+        (Path \ "n")
+          .read[js.Dynamic, Long]
+          .validate(js.Dynamic.literal("n" -> 4.5)) shouldBe
+        (Invalid(Seq(Path \ "n" -> Seq(
+                        ValidationError("error.number", "Long")))))
+      }
+
+      "Float" in {
+        (Path \ "n")
+          .read[js.Dynamic, Float]
+          .validate(js.Dynamic.literal("n" -> 4)) shouldBe (Valid(4))
+        (Path \ "n")
+          .read[js.Dynamic, Float]
+          .validate(js.Dynamic.literal("n" -> "foo")) shouldBe
+        (Invalid(Seq(Path \ "n" -> Seq(
+                        ValidationError("error.number", "Float")))))
+        (Path \ "n")
+          .read[js.Dynamic, Float]
+          .validate(js.Dynamic.literal("n" -> 4.5)) shouldBe (Valid(4.5F))
+      }
+
+      "Double" in {
+        (Path \ "n")
+          .read[js.Dynamic, Double]
+          .validate(js.Dynamic.literal("n" -> 4)) shouldBe (Valid(4))
+        (Path \ "n")
+          .read[js.Dynamic, Double]
+          .validate(js.Dynamic.literal("n" -> "foo")) shouldBe
+        (Invalid(Seq(Path \ "n" -> Seq(
+                        ValidationError("error.number", "Double")))))
+        (Path \ "n")
+          .read[js.Dynamic, Double]
+          .validate(js.Dynamic.literal("n" -> 4.5)) shouldBe (Valid(4.5))
+      }
+
+      "java BigDecimal" in {
+        import java.math.{BigDecimal => jBigDecimal}
+        (Path \ "n")
+          .read[js.Dynamic, jBigDecimal]
+          .validate(js.Dynamic.literal("n" -> 4)) shouldBe
+        (Valid(new jBigDecimal("4")))
+        (Path \ "n")
+          .read[js.Dynamic, jBigDecimal]
+          .validate(js.Dynamic.literal("n" -> "foo")) shouldBe
+        (Invalid(Seq(Path \ "n" -> Seq(
+                        ValidationError("error.number", "BigDecimal")))))
+        (Path \ "n")
+          .read[js.Dynamic, jBigDecimal]
+          .validate(js.Dynamic.literal("n" -> 4.5)) shouldBe
+        (Valid(new jBigDecimal("4.5")))
+      }
+
+      "scala BigDecimal" in {
+        (Path \ "n")
+          .read[js.Dynamic, BigDecimal]
+          .validate(js.Dynamic.literal("n" -> 4)) shouldBe
+        (Valid(BigDecimal(4)))
+        (Path \ "n")
+          .read[js.Dynamic, BigDecimal]
+          .validate(js.Dynamic.literal("n" -> "foo")) shouldBe
+        (Invalid(Seq(Path \ "n" -> Seq(
+                        ValidationError("error.number", "BigDecimal")))))
+        (Path \ "n")
+          .read[js.Dynamic, BigDecimal]
+          .validate(js.Dynamic.literal("n" -> 4.5)) shouldBe
+        (Valid(BigDecimal(4.5)))
+      }
+
+      "String" in {
+        (Path \ "n")
+          .read[js.Dynamic, String]
+          .validate(js.Dynamic.literal("n" -> "foo")) shouldBe (Valid("foo"))
+        (Path \ "n")
+          .read[js.Dynamic, String]
+          .validate(js.Dynamic.literal("n" -> 42)) shouldBe
+        (Invalid(Seq(Path \ "n" -> Seq(
+                        ValidationError("error.invalid", "String")))))
+        (Path \ "n")
+          .read[js.Dynamic, String]
+          .validate(js.Dynamic.literal("n" -> js.Array("foo"))) shouldBe
+        (Invalid(Seq(Path \ "n" -> Seq(
+                        ValidationError("error.invalid", "String")))))
+        (Path \ "o")
+          .read[js.Dynamic, String]
+          .validate(js.Dynamic.literal(
+                  "o" -> js.Dynamic.literal("n" -> "foo"))) shouldBe
+        (Invalid(Seq(Path \ "o" -> Seq(
+                        ValidationError("error.invalid", "String")))))
+      }
+
+      "js.Dictionary" in {
+        (Path \ "o")
+          .read[js.Dynamic, js.Dictionary[js.Dynamic]]
+          .map(_.toSeq)
+          .validate(js.Dynamic.literal(
+                  "o" -> js.Dynamic.literal("n" -> "foo"))) shouldBe
+        (Valid(Seq("n" -> "foo")))
+        (Path \ "n")
+          .read[js.Dynamic, js.Dictionary[js.Dynamic]]
+          .validate(js.Dynamic.literal("n" -> 42)) shouldBe
+        (Invalid(Seq(Path \ "n" -> Seq(
+                        ValidationError("error.invalid", "Object")))))
+        (Path \ "n")
+          .read[js.Dynamic, js.Dictionary[js.Dynamic]]
+          .validate(js.Dynamic.literal("n" -> "foo")) shouldBe
+        (Invalid(Seq(Path \ "n" -> Seq(
+                        ValidationError("error.invalid", "Object")))))
+        (Path \ "n")
+          .read[js.Dynamic, js.Dictionary[js.Dynamic]]
+          .validate(js.Dynamic.literal("n" -> js.Array("foo"))) shouldBe
+        (Invalid(Seq(Path \ "n" -> Seq(
+                        ValidationError("error.invalid", "Object")))))
+      }
+
+      "Boolean" in {
+        (Path \ "n")
+          .read[js.Dynamic, Boolean]
+          .validate(js.Dynamic.literal("n" -> true)) shouldBe (Valid(true))
+        (Path \ "n")
+          .read[js.Dynamic, Boolean]
+          .validate(js.Dynamic.literal("n" -> "foo")) shouldBe
+        (Invalid(Seq(Path \ "n" -> Seq(
+                        ValidationError("error.invalid", "Boolean")))))
+      }
+
+      "Option" in {
+        (Path \ "n")
+          .read[js.Dynamic, Option[Boolean]]
+          .validate(js.Dynamic.literal("n" -> true)) shouldBe
+        (Valid(Some(true)))
+        (Path \ "n")
+          .read[js.Dynamic, Option[Boolean]]
+          .validate(js.Dynamic.literal("n" -> null)) shouldBe (Valid(None))
+        (Path \ "n")
+          .read[js.Dynamic, Option[Boolean]]
+          .validate(js.Dynamic.literal("foo" -> "bar")) shouldBe (Valid(None))
+        (Path \ "n")
+          .read[js.Dynamic, Option[Boolean]]
+          .validate(js.Dynamic.literal("n" -> "bar")) shouldBe
+        (Invalid(Seq(Path \ "n" -> Seq(
+                        ValidationError("error.invalid", "Boolean")))))
+      }
+
+      "Map[String, V]" in {
+        (Path \ "n")
+          .read[js.Dynamic, Map[String, String]]
+          .validate(js.Dynamic.literal(
+                  "n" -> js.Dynamic.literal("foo" -> "bar"))) shouldBe
+        (Valid(Map("foo" -> "bar")))
+        (Path \ "n")
+          .read[js.Dynamic, Map[String, Int]]
+          .validate(js.Dynamic.literal(
+                  "n" -> js.Dynamic.literal("foo" -> 4, "bar" -> 5))) shouldBe
+        (Valid(Map("foo" -> 4, "bar" -> 5)))
+        (Path \ "x")
+          .read[js.Dynamic, Map[String, Int]]
+          .validate(js.Dynamic.literal("n" -> js.Dynamic.literal(
+                      "foo" -> 4, "bar" -> "frack"))) shouldBe
+        (Invalid(Seq(Path \ "x" -> Seq(ValidationError("error.required")))))
+        (Path \ "n")
+          .read[js.Dynamic, Map[String, Int]]
+          .validate(js.Dynamic.literal("n" -> js.Dynamic.literal(
+                      "foo" -> 4, "bar" -> "frack"))) shouldBe
+        (Invalid(Seq(Path \ "n" \ "bar" -> Seq(
+                        ValidationError("error.number", "Int")))))
+      }
+
+      "Traversable" in {
+        (Path \ "n")
+          .read[js.Dynamic, Traversable[String]]
+          .validate(js.Dynamic.literal("n" -> js.Array("foo")))
+          .toOption
+          .get
+          .toSeq shouldBe (Seq("foo"))
+        (Path \ "n")
+          .read[js.Dynamic, Traversable[Int]]
+          .validate(js.Dynamic.literal("n" -> js.Array(1, 2, 3)))
+          .toOption
+          .get
+          .toSeq shouldBe (Seq(1, 2, 3))
+        (Path \ "n")
+          .read[js.Dynamic, Traversable[String]]
+          .validate(js.Dynamic.literal("n" -> "paf")) shouldBe
+        (Invalid(Seq(Path \ "n" -> Seq(
+                        ValidationError("error.invalid", "Array")))))
+      }
+
+      "Array" in {
+        (Path \ "n")
+          .read[js.Dynamic, js.Array[String]]
+          .validate(js.Dynamic.literal("n" -> js.Array("foo")))
+          .toOption
+          .get
+          .toSeq shouldBe (Seq("foo"))
+        (Path \ "n")
+          .read[js.Dynamic, js.Array[Int]]
+          .validate(js.Dynamic.literal("n" -> js.Array(1, 2, 3)))
+          .toOption
+          .get
+          .toSeq shouldBe (Seq(1, 2, 3))
+        (Path \ "n")
+          .read[js.Dynamic, js.Array[String]]
+          .validate(js.Dynamic.literal("n" -> "paf")) shouldBe
+        (Invalid(Seq(Path \ "n" -> Seq(
+                        ValidationError("error.invalid", "Array")))))
+      }
+
+      "Seq" in {
+        (Path \ "n")
+          .read[js.Dynamic, Seq[String]]
+          .validate(js.Dynamic.literal("n" -> js.Array("foo")))
+          .toOption
+          .get shouldBe (Seq("foo"))
+        (Path \ "n")
+          .read[js.Dynamic, Seq[Int]]
+          .validate(js.Dynamic.literal("n" -> js.Array(1, 2, 3)))
+          .toOption
+          .get shouldBe (Seq(1, 2, 3))
+        (Path \ "n")
+          .read[js.Dynamic, Seq[String]]
+          .validate(js.Dynamic.literal("n" -> "paf")) shouldBe
+        (Invalid(Seq(Path \ "n" -> Seq(
+                        ValidationError("error.invalid", "Array")))))
+        (Path \ "n")
+          .read[js.Dynamic, Seq[String]]
+          .validate(js.Dynamic.literal("n" -> js.Array("foo", 2))) shouldBe
+        (Invalid(Seq(Path \ "n" \ 1 -> Seq(
+                        ValidationError("error.invalid", "String")))))
+      }
+    }
+
+    "validate data" in {
+      (Path \ "firstname").from[js.Dynamic](notEmpty).validate(valid) shouldBe
+      (Valid("Julien"))
+
+      val p = (Path \ "informations" \ "label")
+      p.from[js.Dynamic](notEmpty).validate(valid) shouldBe (Valid("Personal"))
+      p.from[js.Dynamic](notEmpty).validate(invalid) shouldBe
+      (Invalid(Seq(p -> Seq(ValidationError("error.required")))))
+    }
+
+    "validate optional" in {
+      (Path \ "firstname").read[js.Dynamic, Option[String]].validate(valid) shouldBe
+      (Valid(Some("Julien")))
+      (Path \ "foobar").read[js.Dynamic, Option[String]].validate(valid) shouldBe
+      (Valid(None))
+    }
+
+    "validate deep" in {
+      val p = (Path \ "informations" \ "label")
+
+      From[js.Dynamic] { __ =>
+        (__ \ "informations").read((__ \ "label").read(notEmpty))
+      }.validate(valid) shouldBe (Valid("Personal"))
+
+      From[js.Dynamic] { __ =>
+        (__ \ "informations").read((__ \ "label").read(notEmpty))
+      }.validate(invalid) shouldBe
+      (Invalid(Seq(p -> Seq(ValidationError("error.required")))))
+    }
+
+    "validate deep optional" in {
+      From[js.Dynamic] { __ =>
+        (__ \ "first" \ "second").read[Option[String]]
+      }.validate(null) shouldBe Valid(None)
+    }
+
+    "coerce type" in {
+      (Path \ "age").read[js.Dynamic, Int].validate(valid) shouldBe (Valid(27))
+      (Path \ "age").from[js.Dynamic](min(20)).validate(valid) shouldBe
+      (Valid(27))
+      (Path \ "age").from[js.Dynamic](max(50)).validate(valid) shouldBe
+      (Valid(27))
+      (Path \ "age").from[js.Dynamic](min(50)).validate(valid) shouldBe
+      (Invalid(Seq((Path \ "age") -> Seq(ValidationError("error.min", 50)))))
+      (Path \ "age").from[js.Dynamic](max(0)).validate(valid) shouldBe
+      (Invalid(Seq((Path \ "age") -> Seq(ValidationError("error.max", 0)))))
+      (Path \ "firstname").read[js.Dynamic, Int].validate(valid) shouldBe
+      (Invalid(Seq((Path \ "firstname") -> Seq(
+                      ValidationError("error.number", "Int")))))
+    }
+
+    "compose constraints" in {
+      val composed = notEmpty |+| minLength(3)
+      (Path \ "firstname").from[js.Dynamic](composed).validate(valid) shouldBe
+      (Valid("Julien"))
+
+      val p = Path \ "informations" \ "label"
+      val err = Invalid(Seq(p -> Seq(ValidationError("error.required"),
+                                     ValidationError("error.minLength", 3))))
+      p.from[js.Dynamic](composed).validate(invalid) shouldBe (err)
+    }
+
+    "compose validations" in {
+      From[js.Dynamic] { __ =>
+        ((__ \ "firstname").read(notEmpty) ~ (__ \ "lastname").read(notEmpty)).tupled
+      }.validate(valid) shouldBe Valid("Julien" -> "Tournay")
+
+      From[js.Dynamic] { __ =>
+        ((__ \ "firstname").read(notEmpty) ~ (__ \ "lastname").read(notEmpty) ~
+            (__ \ "informations" \ "label").read(notEmpty)).tupled
+      }.validate(invalid) shouldBe Invalid(
+          Seq((Path \ "informations" \ "label") -> Seq(
+                  ValidationError("error.required"))))
+    }
+
+    "lift validations to seq validations" in {
+      (Path \ "foo")
+        .from[js.Dynamic](seqR(notEmpty))
+        .validate(js.Dynamic.literal("foo" -> js.Array("bar")))
+        .toOption
+        .get shouldBe (Seq("bar"))
+
+      From[js.Dynamic] { __ =>
+        (__ \ "foo").read((__ \ "foo").read(seqR(notEmpty)))
+      }.validate(js.Dynamic.literal(
+                "foo" -> js.Dynamic.literal("foo" -> js.Array("bar"))))
+        .toOption
+        .get shouldBe (Seq("bar"))
+
+      (Path \ "n")
+        .from[js.Dynamic](seqR(notEmpty))
+        .validate(js.Dynamic.literal("n" -> js.Array("foo", ""))) shouldBe
+      (Invalid(Seq(Path \ "n" \ 1 -> Seq(ValidationError("error.required")))))
+    }
+
+    "validate dependent fields" in {
+      val v = js.Dynamic.literal("login" -> "Alice",
+                                 "password" -> "s3cr3t",
+                                 "verify" -> "s3cr3t")
+
+      val i1 = js.Dynamic.literal("login" -> "Alice",
+                                  "password" -> "s3cr3t",
+                                  "verify" -> "")
+
+      val i2 = js.Dynamic.literal("login" -> "Alice",
+                                  "password" -> "s3cr3t",
+                                  "verify" -> "bam")
+
+      val passRule = From[js.Dynamic] { __ =>
+        ((__ \ "password").read(notEmpty) ~ (__ \ "verify").read(notEmpty)).tupled
+          .andThen(
+            Rule.uncurry(Rules.equalTo[String]).repath(_ => (Path \ "verify")))
+      }
+
+      val rule = From[js.Dynamic] { __ =>
+        ((__ \ "login").read(notEmpty) ~ passRule).tupled
+      }
+
+      rule.validate(v).shouldBe(Valid("Alice" -> "s3cr3t"))
+      rule
+        .validate(i1)
+        .shouldBe(Invalid(Seq(Path \ "verify" -> Seq(
+                        ValidationError("error.required")))))
+      rule
+        .validate(i2)
+        .shouldBe(Invalid(Seq(Path \ "verify" -> Seq(
+                        ValidationError("error.equals", "s3cr3t")))))
+    }
+
+    "validate subclasses (and parse the concrete class)" when {
+
+      trait A
+      case class B(foo: Int) extends A
+      case class C(bar: Int) extends A
+
+      val b = js.Dynamic.literal("name" -> "B", "foo" -> 4)
+      val c = js.Dynamic.literal("name" -> "C", "bar" -> 6)
+      val e = js.Dynamic.literal("name" -> "E", "eee" -> 6)
+
+      val typeInvalid =
+        Invalid(Seq(Path -> Seq(ValidationError("validation.unknownType"))))
+
+      "trying all possible Rules" in {
+        val rb: Rule[js.Dynamic, A] = From[js.Dynamic] { __ =>
+          (__ \ "name").read(Rules.equalTo("B")) *> (__ \ "foo")
+            .read[Int]
+            .map(B.apply)
+        }
+
+        val rc: Rule[js.Dynamic, A] = From[js.Dynamic] { __ =>
+          (__ \ "name").read(Rules.equalTo("C")) *> (__ \ "bar")
+            .read[Int]
+            .map(C.apply)
+        }
+
+        val rule = rb orElse rc orElse Rule(_ => typeInvalid)
+
+        rule.validate(b) shouldBe (Valid(B(4)))
+        rule.validate(c) shouldBe (Valid(C(6)))
+        rule.validate(e) shouldBe
+        (Invalid(Seq(Path -> Seq(ValidationError("validation.unknownType")))))
+      }
+
+      "dicriminating on fields" in {
+
+        val rule = From[js.Dynamic] { __ =>
+          (__ \ "name").read[String].flatMap[A] {
+            case "B" => (__ \ "foo").read[Int].map(B.apply)
+            case "C" => (__ \ "bar").read[Int].map(C.apply)
+            case _ => Rule(_ => typeInvalid)
+          }
+        }
+
+        rule.validate(b) shouldBe (Valid(B(4)))
+        rule.validate(c) shouldBe (Valid(C(6)))
+        rule.validate(e) shouldBe
+        (Invalid(Seq(Path -> Seq(ValidationError("validation.unknownType")))))
+      }
+    }
+
+    "perform complex validation" in {
+
+      case class Contact(firstname: String,
+                         lastname: String,
+                         company: Option[String],
+                         informations: Seq[ContactInformation])
+
+      case class ContactInformation(
+          label: String, email: Option[String], phones: Seq[String])
+
+      val validJson = js.Dynamic.literal(
+          "firstname" -> "Julien",
+          "lastname" -> "Tournay",
+          "age" -> 27,
+          "informations" -> js.Array(js.Dynamic.literal(
+                  "label" -> "Personal",
+                  "email" -> "fakecontact@gmail.com",
+                  "phones" -> js.Array("01.23.45.67.89", "98.76.54.32.10"))))
+
+      val invalidJson = js.Dynamic.literal(
+          "firstname" -> "Julien",
+          "lastname" -> "Tournay",
+          "age" -> 27,
+          "informations" -> js.Array(js.Dynamic.literal(
+                  "label" -> "",
+                  "email" -> "fakecontact@gmail.com",
+                  "phones" -> js.Array("01.23.45.67.89", "98.76.54.32.10"))))
+
+      val infoValidated = From[js.Dynamic] { __ =>
+        ((__ \ "label").read(notEmpty) ~ (__ \ "email").read(optionR(email)) ~
+            (__ \ "phones").read(seqR(notEmpty)))(ContactInformation.apply)
+      }
+
+      val contactValidated = From[js.Dynamic] { __ =>
+        ((__ \ "firstname").read(notEmpty) ~ (__ \ "lastname").read(notEmpty) ~
+            (__ \ "company").read[Option[String]] ~ (__ \ "informations").read(
+                seqR(infoValidated)))(Contact.apply)
+      }
+
+      val expected = Contact(
+          "Julien",
+          "Tournay",
+          None,
+          Seq(ContactInformation("Personal",
+                                 Some("fakecontact@gmail.com"),
+                                 List("01.23.45.67.89", "98.76.54.32.10"))))
+
+      contactValidated.validate(validJson) shouldBe (Valid(expected))
+      contactValidated.validate(invalidJson) shouldBe
+      (Invalid(Seq((Path \ "informations" \ 0 \ "label") -> Seq(
+                      ValidationError("error.required")))))
+    }
+
+    "read recursive" when {
+      case class RecUser(name: String, friends: Seq[RecUser] = Nil)
+      val u = RecUser("bob", Seq(RecUser("tom")))
+
+      val m = js.Dynamic.literal(
+          "name" -> "bob",
+          "friends" -> js.Array(
+              js.Dynamic.literal("name" -> "tom", "friends" -> js.Array())))
+
+      case class User1(name: String, friend: Option[User1] = None)
+      val u1 = User1("bob", Some(User1("tom")))
+      val m1 = js.Dynamic.literal(
+          "name" -> "bob", "friend" -> js.Dynamic.literal("name" -> "tom"))
+
+      "using explicit notation" in {
+        lazy val w: Rule[js.Dynamic, RecUser] = From[js.Dynamic] { __ =>
+          ((__ \ "name").read[String] ~ (__ \ "friends").read(seqR(w)))(
+              RecUser.apply)
+        }
+        w.validate(m) shouldBe Valid(u)
+
+        lazy val w2: Rule[js.Dynamic, RecUser] =
+          ((Path \ "name").read[js.Dynamic, String] ~ (Path \ "friends")
+                .from[js.Dynamic](seqR(w2)))(RecUser.apply)
+        w2.validate(m) shouldBe Valid(u)
+
+        lazy val w3: Rule[js.Dynamic, User1] = From[js.Dynamic] { __ =>
+          ((__ \ "name").read[String] ~ (__ \ "friend").read(optionR(w3)))(
+              User1.apply)
+        }
+        w3.validate(m1) shouldBe Valid(u1)
+      }
+
+      "using implicit notation" in {
+        implicit lazy val w: Rule[js.Dynamic, RecUser] = From[js.Dynamic] {
+          __ =>
+            ((__ \ "name").read[String] ~ (__ \ "friends").read[Seq[RecUser]])(
+                RecUser.apply)
+        }
+        w.validate(m) shouldBe Valid(u)
+
+        implicit lazy val w3: Rule[js.Dynamic, User1] = From[js.Dynamic] {
+          __ =>
+            ((__ \ "name").read[String] ~ (__ \ "friend").read[Option[User1]])(
+                User1.apply)
+        }
+        w3.validate(m1) shouldBe Valid(u1)
+      }
+    }
+
+    "completely generic" in {
+      type OptString[In] = Rule[String, String] => Path => Rule[In,
+                                                                Option[String]]
+
+      def genR[In](opt: OptString[In])(
+          implicit exs: Path => Rule[In, String]) =
+        From[In] { __ =>
+          ((__ \ "name").read(notEmpty) ~ (__ \ "color").read(opt(notEmpty))).tupled
+        }
+
+      val jsonR = {
+        genR[js.Dynamic](optionR(_))
+      }
+
+      val json = js.Dynamic.literal("name" -> "bob", "color" -> "blue")
+      val invalidJson = js.Dynamic.literal("color" -> "blue")
+
+      jsonR.validate(json) shouldBe Valid(("bob", Some("blue")))
+      jsonR.validate(invalidJson) shouldBe Invalid(
+          Seq((Path \ "name", Seq(ValidationError("error.required")))))
+    }
+  }
+}

--- a/validation-jsjson/src/test/scala/WritesSpec.scala
+++ b/validation-jsjson/src/test/scala/WritesSpec.scala
@@ -1,0 +1,364 @@
+import jto.validation._
+import jto.validation.jsjson.Writes._
+import org.scalatest._
+import scala.scalajs.js
+
+class WritesSpec extends WordSpec with Matchers with JsAnyEquality {
+
+  case class Contact(firstname: String,
+                     lastname: String,
+                     company: Option[String],
+                     informations: Seq[ContactInformation])
+
+  case class ContactInformation(
+      label: String, email: Option[String], phones: Seq[String])
+
+  val contact = Contact(
+      "Julien",
+      "Tournay",
+      None,
+      Seq(
+          ContactInformation("Personal",
+                             Some("fakecontact@gmail.com"),
+                             Seq("01.23.45.67.89", "98.76.54.32.10"))))
+
+  val contactJson = js.Dynamic.literal(
+      "firstname" -> "Julien",
+      "lastname" -> "Tournay",
+      "informations" -> js.Array(js.Dynamic.literal(
+              "label" -> "Personal",
+              "email" -> "fakecontact@gmail.com",
+              "phones" -> js.Array("01.23.45.67.89", "98.76.54.32.10"))))
+
+  "Writes" should {
+
+    "write string" in {
+      val w = (Path \ "label").write[String, js.Dynamic]
+      w.writes("Hello World") shouldBe js.Dynamic.literal(
+          "label" -> "Hello World")
+    }
+
+    "ignore values" in {
+      (Path \ "n").write(ignored("foo")).writes("test") shouldBe js.Dynamic
+        .literal("n" -> "foo")
+      (Path \ "n").write(ignored(42)).writes(0) shouldBe js.Dynamic.literal(
+          "n" -> 42)
+    }
+
+    "write option" in {
+      val w = (Path \ "email").write[Option[String], js.Dynamic]
+      w.writes(Some("Hello World")) shouldBe js.Dynamic.literal(
+          "email" -> "Hello World")
+      w.writes(None) shouldBe js.Dynamic.literal()
+
+      (Path \ "n").write(optionW(intW)).writes(Some(5)) shouldBe js.Dynamic
+        .literal("n" -> 5)
+      (Path \ "n").write(optionW(intW)).writes(None) shouldBe js.Dynamic
+        .literal()
+    }
+
+    "write seq" in {
+      val w = (Path \ "phones").write[Seq[String], js.Dynamic]
+      w.writes(Seq("01.23.45.67.89", "98.76.54.32.10")) shouldBe js.Dynamic
+        .literal("phones" -> js.Array("01.23.45.67.89", "98.76.54.32.10"))
+      w.writes(Nil) shouldBe js.Dynamic.literal("phones" -> js.Array())
+    }
+
+    "support primitives types" when {
+
+      "Int" in {
+        (Path \ "n").write[Int, js.Dynamic].writes(4) shouldBe
+        (js.Dynamic.literal("n" -> 4))
+        (Path \ "n" \ "o").write[Int, js.Dynamic].writes(4) shouldBe
+        (js.Dynamic.literal("n" -> js.Dynamic.literal("o" -> 4)))
+        (Path \ "n" \ "o" \ "p").write[Int, js.Dynamic].writes(4) shouldBe
+        (js.Dynamic.literal("n" -> js.Dynamic.literal(
+                    "o" -> js.Dynamic.literal("p" -> 4))))
+      }
+
+      "Short" in {
+        (Path \ "n").write[Short, js.Dynamic].writes(4) shouldBe
+        (js.Dynamic.literal("n" -> 4))
+        (Path \ "n" \ "o").write[Short, js.Dynamic].writes(4) shouldBe
+        (js.Dynamic.literal("n" -> js.Dynamic.literal("o" -> 4)))
+        (Path \ "n" \ "o" \ "p").write[Short, js.Dynamic].writes(4) shouldBe
+        (js.Dynamic.literal("n" -> js.Dynamic.literal(
+                    "o" -> js.Dynamic.literal("p" -> 4))))
+      }
+
+      "Long" in {
+        (Path \ "n").write[Long, js.Dynamic].writes(4) shouldBe
+        (js.Dynamic.literal("n" -> 4))
+        (Path \ "n" \ "o").write[Long, js.Dynamic].writes(4) shouldBe
+        (js.Dynamic.literal("n" -> js.Dynamic.literal("o" -> 4)))
+        (Path \ "n" \ "o" \ "p").write[Long, js.Dynamic].writes(4) shouldBe
+        (js.Dynamic.literal("n" -> js.Dynamic.literal(
+                    "o" -> js.Dynamic.literal("p" -> 4))))
+      }
+
+      "Float" in {
+        (Path \ "n").write[Float, js.Dynamic].writes(4.5f) shouldBe
+        (js.Dynamic.literal("n" -> 4.5))
+        (Path \ "n" \ "o").write[Float, js.Dynamic].writes(4.5f) shouldBe
+        (js.Dynamic.literal("n" -> js.Dynamic.literal("o" -> 4.5)))
+        (Path \ "n" \ "o" \ "p").write[Float, js.Dynamic].writes(4.5f) shouldBe
+        (js.Dynamic.literal("n" -> js.Dynamic.literal(
+                    "o" -> js.Dynamic.literal("p" -> 4.5))))
+      }
+
+      "Double" in {
+        (Path \ "n").write[Double, js.Dynamic].writes(4d) shouldBe
+        (js.Dynamic.literal("n" -> 4.0))
+        (Path \ "n" \ "o").write[Double, js.Dynamic].writes(4.5d) shouldBe
+        (js.Dynamic.literal("n" -> js.Dynamic.literal("o" -> 4.5)))
+        (Path \ "n" \ "o" \ "p").write[Double, js.Dynamic].writes(4.5d) shouldBe
+        (js.Dynamic.literal("n" -> js.Dynamic.literal(
+                    "o" -> js.Dynamic.literal("p" -> 4.5))))
+      }
+
+      "scala BigDecimal" in {
+        (Path \ "n").write[BigDecimal, js.Dynamic].writes(BigDecimal("4.5")) shouldBe
+        (js.Dynamic.literal("n" -> "4.5"))
+        (Path \ "n" \ "o")
+          .write[BigDecimal, js.Dynamic]
+          .writes(BigDecimal("4.5")) shouldBe
+        (js.Dynamic.literal("n" -> js.Dynamic.literal("o" -> "4.5")))
+        (Path \ "n" \ "o" \ "p")
+          .write[BigDecimal, js.Dynamic]
+          .writes(BigDecimal("4.5")) shouldBe
+        (js.Dynamic.literal("n" -> js.Dynamic.literal(
+                    "o" -> js.Dynamic.literal("p" -> "4.5"))))
+      }
+
+      "Boolean" in {
+        (Path \ "n").write[Boolean, js.Dynamic].writes(true) shouldBe
+        (js.Dynamic.literal("n" -> true))
+        (Path \ "n" \ "o").write[Boolean, js.Dynamic].writes(false) shouldBe
+        (js.Dynamic.literal("n" -> js.Dynamic.literal("o" -> false)))
+        (Path \ "n" \ "o" \ "p").write[Boolean, js.Dynamic].writes(true) shouldBe
+        (js.Dynamic.literal("n" -> js.Dynamic.literal(
+                    "o" -> js.Dynamic.literal("p" -> true))))
+      }
+
+      "String" in {
+        (Path \ "n").write[String, js.Dynamic].writes("foo") shouldBe
+        (js.Dynamic.literal("n" -> "foo"))
+        (Path \ "n" \ "o").write[String, js.Dynamic].writes("foo") shouldBe
+        (js.Dynamic.literal("n" -> js.Dynamic.literal("o" -> "foo")))
+        (Path \ "n" \ "o" \ "p").write[String, js.Dynamic].writes("foo") shouldBe
+        (js.Dynamic.literal("n" -> js.Dynamic.literal(
+                    "o" -> js.Dynamic.literal("p" -> "foo"))))
+      }
+
+      "Option" in {
+        (Path \ "n").write[Option[String], js.Dynamic].writes(Some("foo")) shouldBe
+        (js.Dynamic.literal("n" -> "foo"))
+        (Path \ "n" \ "o")
+          .write[Option[String], js.Dynamic]
+          .writes(Some("foo")) shouldBe
+        (js.Dynamic.literal("n" -> js.Dynamic.literal("o" -> "foo")))
+        (Path \ "n" \ "o" \ "p")
+          .write[Option[String], js.Dynamic]
+          .writes(Some("foo")) shouldBe
+        (js.Dynamic.literal("n" -> js.Dynamic.literal(
+                    "o" -> js.Dynamic.literal("p" -> "foo"))))
+
+        (Path \ "n").write[Option[String], js.Dynamic].writes(None) shouldBe
+        (js.Dynamic.literal())
+        (Path \ "n" \ "o").write[Option[String], js.Dynamic].writes(None) shouldBe
+        (js.Dynamic.literal())
+        (Path \ "n" \ "o" \ "p").write[Option[String], js.Dynamic].writes(None) shouldBe
+        (js.Dynamic.literal())
+      }
+
+      "Map[String, Seq[V]]" in {
+        (Path \ "n")
+          .write[Map[String, Seq[String]], js.Dynamic]
+          .writes(Map("foo" -> Seq("bar"))) shouldBe
+        (js.Dynamic.literal(
+                "n" -> js.Dynamic.literal("foo" -> js.Array("bar"))))
+        (Path \ "n")
+          .write[Map[String, Seq[Int]], js.Dynamic]
+          .writes(Map("foo" -> Seq(4))) shouldBe
+        (js.Dynamic.literal("n" -> js.Dynamic.literal("foo" -> js.Array(4))))
+        (Path \ "n" \ "o")
+          .write[Map[String, Seq[Int]], js.Dynamic]
+          .writes(Map("foo" -> Seq(4))) shouldBe
+        (js.Dynamic.literal("n" -> js.Dynamic.literal(
+                    "o" -> js.Dynamic.literal("foo" -> js.Array(4)))))
+        (Path \ "n" \ "o")
+          .write[Map[String, Int], js.Dynamic]
+          .writes(Map("foo" -> 4)) shouldBe
+        (js.Dynamic.literal("n" -> js.Dynamic.literal(
+                    "o" -> js.Dynamic.literal("foo" -> 4))))
+        (Path \ "n" \ "o")
+          .write[Map[String, Int], js.Dynamic]
+          .writes(Map.empty) shouldBe
+        (js.Dynamic.literal(
+                "n" -> js.Dynamic.literal("o" -> js.Dynamic.literal())))
+      }
+
+      "Traversable" in {
+        (Path \ "n")
+          .write[Traversable[String], js.Dynamic]
+          .writes(Array("foo", "bar")) shouldBe
+        (js.Dynamic.literal("n" -> js.Array("foo", "bar")))
+        (Path \ "n" \ "o")
+          .write[Traversable[String], js.Dynamic]
+          .writes(Array("foo", "bar")) shouldBe
+        (js.Dynamic.literal(
+                "n" -> js.Dynamic.literal("o" -> js.Array("foo", "bar"))))
+        (Path \ "n" \ "o" \ "p")
+          .write[Traversable[String], js.Dynamic]
+          .writes(Array("foo", "bar")) shouldBe
+        (js.Dynamic.literal("n" -> js.Dynamic.literal(
+                    "o" -> js.Dynamic.literal("p" -> js.Array("foo", "bar")))))
+
+        (Path \ "n")
+          .write[Traversable[String], js.Dynamic]
+          .writes(Array[String]()) shouldBe
+        (js.Dynamic.literal("n" -> js.Array()))
+        (Path \ "n" \ "o")
+          .write[Traversable[String], js.Dynamic]
+          .writes(Array[String]()) shouldBe
+        (js.Dynamic.literal("n" -> js.Dynamic.literal("o" -> js.Array())))
+        (Path \ "n" \ "o" \ "p")
+          .write[Traversable[String], js.Dynamic]
+          .writes(Array[String]()) shouldBe
+        (js.Dynamic.literal("n" -> js.Dynamic.literal(
+                    "o" -> js.Dynamic.literal("p" -> js.Array()))))
+      }
+
+      "Array" in {
+        (Path \ "n")
+          .write[Array[String], js.Dynamic]
+          .writes(Array("foo", "bar")) shouldBe
+        (js.Dynamic.literal("n" -> js.Array("foo", "bar")))
+        (Path \ "n" \ "o")
+          .write[Array[String], js.Dynamic]
+          .writes(Array("foo", "bar")) shouldBe
+        (js.Dynamic.literal(
+                "n" -> js.Dynamic.literal("o" -> js.Array("foo", "bar"))))
+        (Path \ "n" \ "o" \ "p")
+          .write[Array[String], js.Dynamic]
+          .writes(Array("foo", "bar")) shouldBe
+        (js.Dynamic.literal("n" -> js.Dynamic.literal(
+                    "o" -> js.Dynamic.literal("p" -> js.Array("foo", "bar")))))
+
+        (Path \ "n").write[Array[String], js.Dynamic].writes(Array()) shouldBe
+        (js.Dynamic.literal("n" -> js.Array()))
+        (Path \ "n" \ "o").write[Array[String], js.Dynamic].writes(Array()) shouldBe
+        (js.Dynamic.literal("n" -> js.Dynamic.literal("o" -> js.Array())))
+        (Path \ "n" \ "o" \ "p")
+          .write[Array[String], js.Dynamic]
+          .writes(Array()) shouldBe
+        (js.Dynamic.literal("n" -> js.Dynamic.literal(
+                    "o" -> js.Dynamic.literal("p" -> js.Array()))))
+      }
+
+      "Seq" in {
+        (Path \ "n").write[Seq[String], js.Dynamic].writes(Seq("foo", "bar")) shouldBe
+        (js.Dynamic.literal("n" -> js.Array("foo", "bar")))
+        (Path \ "n" \ "o")
+          .write[Seq[String], js.Dynamic]
+          .writes(Seq("foo", "bar")) shouldBe
+        (js.Dynamic.literal(
+                "n" -> js.Dynamic.literal("o" -> js.Array("foo", "bar"))))
+        (Path \ "n" \ "o" \ "p")
+          .write[Seq[String], js.Dynamic]
+          .writes(Seq("foo", "bar")) shouldBe
+        (js.Dynamic.literal("n" -> js.Dynamic.literal(
+                    "o" -> js.Dynamic.literal("p" -> js.Array("foo", "bar")))))
+
+        (Path \ "n").write[Seq[String], js.Dynamic].writes(Nil) shouldBe
+        (js.Dynamic.literal("n" -> js.Array()))
+        (Path \ "n" \ "o").write[Seq[String], js.Dynamic].writes(Nil) shouldBe
+        (js.Dynamic.literal("n" -> js.Dynamic.literal("o" -> js.Array())))
+        (Path \ "n" \ "o" \ "p").write[Seq[String], js.Dynamic].writes(Nil) shouldBe
+        (js.Dynamic.literal("n" -> js.Dynamic.literal(
+                    "o" -> js.Dynamic.literal("p" -> js.Array()))))
+      }
+    }
+
+    "compose" in {
+      val w = To[js.Dynamic] { __ =>
+        ((__ \ "email").write[Option[String]] ~ (__ \ "phones")
+              .write[Seq[String]]).tupled
+      }
+
+      val v = Some("jto@foobar.com") -> Seq("01.23.45.67.89", "98.76.54.32.10")
+
+      w.writes(v) shouldBe js.Dynamic.literal(
+          "email" -> "jto@foobar.com",
+          "phones" -> js.Array("01.23.45.67.89", "98.76.54.32.10"))
+      w.writes(Some("jto@foobar.com") -> Nil) shouldBe js.Dynamic.literal(
+          "email" -> "jto@foobar.com", "phones" -> js.Array())
+      w.writes(None -> Nil) shouldBe js.Dynamic.literal("phones" -> js.Array())
+    }
+
+    "write Map" in {
+      implicit val contactInformation = To[js.Dynamic] { __ =>
+        ((__ \ "label").write[String] ~ (__ \ "email").write[Option[String]] ~
+            (__ \ "phones").write[Seq[String]])
+          .unlifted(ContactInformation.unapply)
+      }
+
+      implicit val contactWrite = To[js.Dynamic] { __ =>
+        ((__ \ "firstname").write[String] ~ (__ \ "lastname").write[String] ~
+            (__ \ "company").write[Option[String]] ~ (__ \ "informations")
+              .write[Seq[ContactInformation]]).unlifted(Contact.unapply)
+      }
+
+      contactWrite.writes(contact) shouldBe contactJson
+    }
+
+    "write recursive" when {
+      case class RecUser(name: String, friends: List[RecUser] = Nil)
+      val u = RecUser("bob", List(RecUser("tom")))
+
+      val m = js.Dynamic.literal(
+          "name" -> "bob",
+          "friends" -> js.Array(
+              js.Dynamic.literal("name" -> "tom", "friends" -> js.Array())))
+
+      case class User1(name: String, friend: Option[User1] = None)
+      val u1 = User1("bob", Some(User1("tom")))
+      val m1 = js.Dynamic.literal(
+          "name" -> "bob", "friend" -> js.Dynamic.literal("name" -> "tom"))
+
+      "using explicit notation" in {
+        lazy val w: Write[RecUser, js.Dynamic] = To[js.Dynamic] { __ =>
+          ((__ \ "name").write[String] ~ (__ \ "friends").write(seqW(w)))
+            .unlifted(RecUser.unapply)
+        }
+        w.writes(u) shouldBe m
+
+        lazy val w2: Write[RecUser, js.Dynamic] =
+          ((Path \ "name").write[String, js.Dynamic] ~ (Path \ "friends")
+                .write(seqW(w2))).unlifted(RecUser.unapply)
+        w2.writes(u) shouldBe m
+
+        lazy val w3: Write[User1, js.Dynamic] = To[js.Dynamic] { __ =>
+          ((__ \ "name").write[String] ~ (__ \ "friend").write(optionW(w3)))
+            .unlifted(User1.unapply)
+        }
+        w3.writes(u1) shouldBe m1
+      }
+
+      "using implicit notation" in {
+        implicit lazy val w: Write[RecUser, js.Dynamic] = To[js.Dynamic] {
+          __ =>
+            ((__ \ "name").write[String] ~ (__ \ "friends")
+                  .write[Seq[RecUser]]).unlifted(RecUser.unapply)
+        }
+        w.writes(u) shouldBe m
+
+        implicit lazy val w3: Write[User1, js.Dynamic] = To[js.Dynamic] { __ =>
+          ((__ \ "name").write[String] ~ (__ \ "friend").write[Option[User1]])
+            .unlifted(User1.unapply)
+        }
+        w3.writes(u1) shouldBe m1
+      }
+    }
+  }
+}

--- a/validation-playjson/src/test/scala/WritesSpec.scala
+++ b/validation-playjson/src/test/scala/WritesSpec.scala
@@ -17,7 +17,8 @@ class WritesSpec extends WordSpec with Matchers {
       "Julien",
       "Tournay",
       None,
-      Seq(ContactInformation("Personal",
+      Seq(
+          ContactInformation("Personal",
                              Some("fakecontact@gmail.com"),
                              Seq("01.23.45.67.89", "98.76.54.32.10"))))
 

--- a/validation-xml/src/test/scala/WritesSpec.scala
+++ b/validation-xml/src/test/scala/WritesSpec.scala
@@ -22,7 +22,8 @@ class WritesSpec extends WordSpec with Matchers {
       "Julien",
       "Tournay",
       None,
-      Seq(ContactInformation("Personal",
+      Seq(
+          ContactInformation("Personal",
                              Some("fakecontact@gmail.com"),
                              Seq("01.23.45.67.89", "98.76.54.32.10"))))
 

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "2.0-SNAPSHOT"
+version in ThisBuild := "2.0"


### PR DESCRIPTION
As of right now there is no available parsers for [json4s-ast](https://github.com/json4s/json4s-ast), neither on the JVM nor on JS, this means to have cross compile validation used from vanilla JavaScript. This PR reverts the jsjson commit from #42, which the tut on Play integration relies on. Now I think these are the options:

1. Remove the `json4s-ast` sub-project and give up on cross compilation (we could maybe revert to proper `json4s` (JVM only) in cases someone uses that...)

2. Roll our own parser for `json4s-ast` or equivalent (the fact that we need a fast and a safe version or the ADT make no sense to me).

3. Provide functions the following functions, which would let the users cross compile `json4s-ast` `Rule`s and `Write`s, and lift them to platform specific stuff:
    - `playjson` → `json4s-ast`
    - `playjson` ← `json4s-ast`
    - `jsjson` → `json4s-ast`
    - `jsjson` ← `json4s-ast`

4. Decouple the description of validations from their target format.