### PR TITLE
Add sbt validate, open JVM projects by default

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -14,7 +14,7 @@ val scalacVersion = "2.11.8"
 val scalatestVersion = "3.0.0-M16-SNAP5"
 val scalaXmlVersion = "1.0.5"
 
-lazy val root = aggregate("validation", validationJVM, validationJS).in(file("."))
+lazy val root = aggregate("validation", validationJVM, validationJS, `validation-docs`).in(file("."))
 lazy val validationJVM = aggregate("validationJVM", coreJVM, formJVM, delimitedJVM, json4sJVM, `validation-playjson`, `validation-xml`)
 lazy val validationJS = aggregate("validationJS", coreJS, formJS, delimitedJS, json4sJS)
 
@@ -166,3 +166,7 @@ val dontPublish = Seq(
   publishLocal := (),
   publishArtifact := false
 )
+
+onLoad in Global := (Command.process("project validationJVM", _: State)) compose (onLoad in Global).value
+
+addCommandAlias("validate", ";validationJVM/test;validationJS/test;validation-docs/tut")

--- a/validation-playjson/src/test/scala/WritesSpec.scala
+++ b/validation-playjson/src/test/scala/WritesSpec.scala
@@ -17,7 +17,8 @@ class WritesSpec extends WordSpec with Matchers {
       "Julien",
       "Tournay",
       None,
-      Seq(ContactInformation("Personal",
+      Seq(
+          ContactInformation("Personal",
                              Some("fakecontact@gmail.com"),
                              Seq("01.23.45.67.89", "98.76.54.32.10"))))
 

--- a/validation-xml/src/test/scala/WritesSpec.scala
+++ b/validation-xml/src/test/scala/WritesSpec.scala
@@ -22,7 +22,8 @@ class WritesSpec extends WordSpec with Matchers {
       "Julien",
       "Tournay",
       None,
-      Seq(ContactInformation("Personal",
+      Seq(
+          ContactInformation("Personal",
                              Some("fakecontact@gmail.com"),
                              Seq("01.23.45.67.89", "98.76.54.32.10"))))
 


### PR DESCRIPTION
This PR change the default sbt project to the JVM versions, such that `sbt ~test:compile` and `sbt test` are really quick. It also add a `sbt validate` command which runs tests on both platforms and rebuilds the documentation (which only makes sense on top of #52).