### PR TITLE
Add .as[MyCC] syntax and Tupler macro

### DIFF
--- a/project/Boilerplate.scala
+++ b/project/Boilerplate.scala
@@ -21,10 +21,7 @@ object Boilerplate {
     }
   }
 
-  val header = """
-    // Auto-generated boilerplate
-    // $COVERAGE-OFF$Disabling coverage for generated code
-  """
+  val header = "// $COVERAGE-OFF$Disabling coverage for auto-generated boilerplate"
 
   val minArity = 2
   val maxArity = 22
@@ -109,14 +106,20 @@ object Boilerplate {
         -  class InvariantSyntax$arity[${`A..N`}](m1: M[${`A~N-1`}], m2: M[A${arity-1}]) {
         -    $next
         -
-        -    def apply[B](f1: (${`A..N`}) => B, f2: B => (${`A..N`}))(implicit fu: Invariant[M]): M[B] =
+        -    def apply[B](f1: ${`(A..N)`} => B, f2: B => ${`(A..N)`})(implicit fu: Invariant[M]): M[B] =
         -      fu.imap[${`A~N`}, B](
         -        combine(m1, m2))({ case ${`a~n`} => f1(${`a..n`}) })(
         -        (b: B) => { val (${`a..n`}) = f2(b); ${`new ~(.., n)`} }
         -      )
         -
-        -    def tupled(implicit fu: Invariant[M]): M[(${`A..N`})] =
-        -      apply[(${`A..N`})]({ (${`a:A..n:N`}) => (${`a..n`}) }, { (a: (${`A..N`})) => (${`a._1..a._N`}) })
+        -    def as[B](implicit t: CaseClassTupler.Aux[B, ${`(A..N)`}], fu: Invariant[M]): M[B] =
+        -      fu.imap[${`A~N`}, B](
+        -        combine(m1, m2))({ case ${`a~n`} => t.from(${`(a..n)`}) })(
+        -        (b: B) => { val (${`a..n`}) = t.to(b); ${`new ~(.., n)`} }
+        -      )
+        -
+        -    def tupled(implicit fu: Invariant[M]): M[${`(A..N)`}] =
+        -      apply[${`(A..N)`}]({ (${`a:A..n:N`}) => (${`a..n`}) }, { (a: ${`(A..N)`}) => (${`a._1..a._N`}) })
         -  }
         -
         |}
@@ -143,11 +146,14 @@ object Boilerplate {
         -  class FunctorSyntax${arity}[${`A..N`}](m1: M[${`A~N-1`}], m2: M[A${arity-1}]) {
         -    $next
         -
-        -    def apply[B](f: (${`A..N`}) => B)(implicit fu: Functor[M]): M[B] =
-        -      fu.map[${`A~N`}, B](combine(m1, m2))({ case ${`a~n`} => f(${`a..n`}) })
+        -    def apply[B](f: ${`(A..N)`} => B)(implicit fu: Functor[M]): M[B] =
+        -      fu.map[${`A~N`}, B](combine(m1, m2))({ case ${`a~n`} => f(${`a..n` }) })
         -
-        -    def tupled(implicit fu: Functor[M]): M[(${`A..N`})] =
-        -      apply[(${`A..N`})]({ (${`a:A..n:N`}) => (${`a..n`}) })
+        -    def as[B](implicit t: CaseClassTupler.Aux[B, ${`(A..N)`}], fu: Functor[M]): M[B] =
+        -      fu.map[${`A~N`}, B](combine(m1, m2))({ case ${`a~n`} => t.from(${`(a..n)`}) })
+        -
+        -    def tupled(implicit fu: Functor[M]): M[${`(A..N)`}] =
+        -      apply[${`(A..N)`}]({ (${`a:A..n:N`}) => (${`a..n`}) })
         -  }
         -
         |}
@@ -174,11 +180,14 @@ object Boilerplate {
         -  class ContravariantSyntax${arity}[${`A..N`}](m1: M[${`A~N-1`}], m2: M[A${arity-1}]) {
         -    $next
         -
-        -    def apply[B](f: B => (${`A..N`}))(implicit fu: Contravariant[M]): M[B] =
-        -      fu.contramap(combine(m1, m2))((b: B) => { val (${`a..n`}) = f(b); ${`new ~(.., n)`} })
+        -    def apply[B](f: B => ${`(A..N)`})(implicit fu: Contravariant[M]): M[B] =
+        -      fu.contramap[${`A~N`}, B](combine(m1, m2))((b: B) => { val (${`a..n`}) = f(b); ${`new ~(.., n)`} })
         -
-        -    def tupled(implicit fu: Contravariant[M]): M[(${`A..N`})] =
-        -      apply[(${`A..N`})]({ (a: (${`A..N`})) => (${`a._1..a._N`}) })
+        -    def as[B](implicit t: CaseClassTupler.Aux[B, ${`(A..N)`}], fu: Contravariant[M]): M[B] =
+        -      fu.contramap[${`A~N`}, B](combine(m1, m2))((b: B) => { val (${`a..n`}) = t.to(b); ${`new ~(.., n)`} })
+        -
+        -    def tupled(implicit fu: Contravariant[M]): M[${`(A..N)`}] =
+        -      apply[${`(A..N)`}]({ (a: ${`(A..N)`}) => (${`a._1..a._N`}) })
         -  }
         -
         |}

--- a/validation-core/src/main/scala/CaseClassTupler.scala
+++ b/validation-core/src/main/scala/CaseClassTupler.scala
@@ -1,0 +1,52 @@
+package jto.validation
+
+/**
+ * Lightweight alternative to `shapeless.Generic` limited to products and targeting `TupleN`s.
+ */
+trait CaseClassTupler[T] {
+  type TupleRepr
+
+  def to(t: T): TupleRepr
+  def from(t: TupleRepr): T
+}
+
+object CaseClassTupler {
+  type Aux[T, R] = CaseClassTupler[T] { type TupleRepr = R }
+  def apply[T](implicit t: CaseClassTupler[T]): Aux[T, t.TupleRepr] = t
+
+  implicit def materialize[T, R]: Aux[T, R] = macro CaseClassTuplerMacro.mkCaseClassTupler[T, R]
+}
+
+object CaseClassTuplerMacro {
+  import scala.reflect.macros.whitebox.Context
+
+  def mkCaseClassTupler[T: c.WeakTypeTag, R: c.WeakTypeTag](c: Context): c.Tree = {
+    import c.universe._
+
+    val tpe: Type = weakTypeOf[T]
+    val helper = new { val context: c.type = c } with MappingMacros.Helper
+    import helper._
+
+    val (apply, unapply) = lookup[T]
+    val (_, constructorParamss) = getConstructorParamss[T]
+    val isArityOne: Boolean = constructorParamss.headOption.toList.flatten.size == 1
+
+    val TypeRef(_, _, ps) = unapply.returnType
+    val tupleRepr = tq"${ps.head}"
+
+    val to = q"""_root_.scala.Function.unlift($unapply _)(c)"""
+    val from = if (isArityOne) q"""$apply(t)""" else q"""($apply _).tupled(t)"""
+
+    val clsName = TypeName(c.freshName("anon$"))
+    q"""
+      {
+        final class $clsName extends _root_.jto.validation.CaseClassTupler[$tpe] {
+          type TupleRepr = $tupleRepr
+          def to(c: $tpe): TupleRepr   = $to
+          def from(t: TupleRepr): $tpe = $from
+        }
+        new $clsName(): _root_.jto.validation.CaseClassTupler.Aux[$tpe, $tupleRepr]
+      }
+    """
+  }
+}

--- a/validation-core/src/main/scala/MappingMacros.scala
+++ b/validation-core/src/main/scala/MappingMacros.scala
@@ -3,7 +3,7 @@ package jto.validation
 object MappingMacros {
   import scala.reflect.macros.blackbox.Context
 
-  private abstract class Helper {
+  private[validation] abstract class Helper {
     val context: Context
     import context.universe._
 
@@ -117,10 +117,10 @@ object MappingMacros {
         val typeApply = ts.foldLeft(q"$w1 ~ $w2") { (t1, t2) =>
           q"$t1 ~ $t2"
         }
-        q"($typeApply)(Function.unlift($unapply(_)))"
+        q"($typeApply)(_root_.scala.Function.unlift($unapply(_)))"
 
       case w1 :: Nil =>
-        q"$w1.contramap(Function.unlift($unapply(_)): $t)"
+        q"$w1.contramap(_root_.scala.Function.unlift($unapply(_)): $t)"
     }
 
     // XXX: recursive values need the user to use explcitly typed implicit val

--- a/validation-core/src/test/scala/CaseClassTuplerSpec.scala
+++ b/validation-core/src/test/scala/CaseClassTuplerSpec.scala
@@ -1,0 +1,65 @@
+import org.scalatest._
+import jto.validation._
+
+class CaseClassTuplerSpec extends WordSpec with Matchers {
+  "CaseClassTupler" should {
+    "round trip for small example" in {
+      val tupler = CaseClassTupler[Toto]
+      implicitly[tupler.TupleRepr =:= (String, Int)]
+
+      val toto  = Toto("s", 1)
+      val tuple = ("s", 1)
+      assert(tupler.to(toto)    == tuple)
+      assert(tupler.from(tuple) == toto)
+    }
+
+    "round trip with many fields" in {
+      val tupler = CaseClassTupler[X]
+      type S = String
+      implicitly[tupler.TupleRepr =:= (S, S, S, S, S, S, S, S, S, S, S, S, S, S, S, S, S, S, S, S, S)]
+
+      val x = X("1", "2", "3", "4", "5", "6", "7", "8", "9", "A", "B", "C", "D", "E", "F", "G", "H", "I", "J", "K", "L")
+      val t =  ("1", "2", "3", "4", "5", "6", "7", "8", "9", "A", "B", "C", "D", "E", "F", "G", "H", "I", "J", "K", "L")
+      assert(tupler.to(x)   == t)
+      assert(tupler.from(t) == x)
+    }
+
+    "single field case class" in {
+      val tupler = CaseClassTupler[Cat]
+      implicitly[tupler.TupleRepr =:= String]
+
+      val cat   = Cat("s")
+      val tuple = "s"
+      assert(tupler.to(cat)    == tuple)
+      assert(tupler.from(tuple) == cat)
+    }
+  }
+}
+
+case class Cat(name: String)
+
+case class Toto(s: String, i: Int)
+
+case class X(
+  _1: String,
+  _2: String,
+  _3: String,
+  _4: String,
+  _5: String,
+  _6: String,
+  _7: String,
+  _8: String,
+  _9: String,
+  _10: String,
+  _11: String,
+  _12: String,
+  _13: String,
+  _14: String,
+  _15: String,
+  _16: String,
+  _17: String,
+  _18: String,
+  _19: String,
+  _20: String,
+  _21: String
+)


### PR DESCRIPTION
This PR adds a new type class + macro + boilerplate to let you replace

``` scala
.apply(User.apply, Function.unlift(User.unapply))
```

by

``` scala
.as[User]
```

(Complete example:)

``` scala
val userFormat: Format[JsValue, JsObject, User] =
  Formatting[JsValue, JsObject] { __ =>
    (
      (__ \ "name").format[String] ~
      (__ \ "age").format[Int] ~
      (__ \ "email").format[Option[String]] ~
      (__ \ "isAlive").format[Boolean]
    ).as[User]
  }
```

Note that Circe and Scodec provide similar syntax, but their implementation relies on shapeless' macros and boilerplate, probably something along the lines of:

``` scala
def as[C]
  (implicit
    g: Generic[C],
    t: Tupler[g.Repr],
    u: Generic[t.Out]
  ) = ...
```

This syntax was added for the three builders (`From`, `To` and `Formatting`). The PR is to be completed with doc and additional tests if you feel like going forward with it.
