### PR TITLE
UFree

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -3,7 +3,7 @@ val repo = "git@github.com:jto/validation.git"
 val org = "io.github.jto"
 val license = ("Apache License", url("http://www.apache.org/licenses/LICENSE-2.0.txt"))
 
-val catsVersion = "0.6.0"
+val catsVersion = "0.7.0-SNAPSHOT"
 val jodaConvertVersion = "1.8.1"
 val jodaTimeVersion = "2.9.4"
 val kindProjectorVersion = "0.7.1"

--- a/project/Boilerplate.scala
+++ b/project/Boilerplate.scala
@@ -21,10 +21,7 @@ object Boilerplate {
     }
   }
 
-  val header = """
-    // Auto-generated boilerplate
-    // $COVERAGE-OFF$Disabling coverage for generated code
-  """
+  val header = "// $COVERAGE-OFF$Disabling coverage for auto-generated boilerplate"
 
   val minArity = 2
   val maxArity = 22
@@ -109,14 +106,20 @@ object Boilerplate {
         -  class InvariantSyntax$arity[${`A..N`}](m1: M[${`A~N-1`}], m2: M[A${arity-1}]) {
         -    $next
         -
-        -    def apply[B](f1: (${`A..N`}) => B, f2: B => (${`A..N`}))(implicit fu: Invariant[M]): M[B] =
+        -    def apply[B](f1: ${`(A..N)`} => B, f2: B => ${`(A..N)`})(implicit fu: Invariant[M]): M[B] =
         -      fu.imap[${`A~N`}, B](
         -        combine(m1, m2))({ case ${`a~n`} => f1(${`a..n`}) })(
         -        (b: B) => { val (${`a..n`}) = f2(b); ${`new ~(.., n)`} }
         -      )
         -
-        -    def tupled(implicit fu: Invariant[M]): M[(${`A..N`})] =
-        -      apply[(${`A..N`})]({ (${`a:A..n:N`}) => (${`a..n`}) }, { (a: (${`A..N`})) => (${`a._1..a._N`}) })
+        -    def as[B](implicit t: CaseClassTupler.Aux[B, ${`(A..N)`}], fu: Invariant[M]): M[B] =
+        -      fu.imap[${`A~N`}, B](
+        -        combine(m1, m2))({ case ${`a~n`} => t.from(${`(a..n)`}) })(
+        -        (b: B) => { val (${`a..n`}) = t.to(b); ${`new ~(.., n)`} }
+        -      )
+        -
+        -    def tupled(implicit fu: Invariant[M]): M[${`(A..N)`}] =
+        -      apply[${`(A..N)`}]({ (${`a:A..n:N`}) => (${`a..n`}) }, { (a: ${`(A..N)`}) => (${`a._1..a._N`}) })
         -  }
         -
         |}
@@ -143,11 +146,14 @@ object Boilerplate {
         -  class FunctorSyntax${arity}[${`A..N`}](m1: M[${`A~N-1`}], m2: M[A${arity-1}]) {
         -    $next
         -
-        -    def apply[B](f: (${`A..N`}) => B)(implicit fu: Functor[M]): M[B] =
-        -      fu.map[${`A~N`}, B](combine(m1, m2))({ case ${`a~n`} => f(${`a..n`}) })
+        -    def apply[B](f: ${`(A..N)`} => B)(implicit fu: Functor[M]): M[B] =
+        -      fu.map[${`A~N`}, B](combine(m1, m2))({ case ${`a~n`} => f(${`a..n` }) })
         -
-        -    def tupled(implicit fu: Functor[M]): M[(${`A..N`})] =
-        -      apply[(${`A..N`})]({ (${`a:A..n:N`}) => (${`a..n`}) })
+        -    def as[B](implicit t: CaseClassTupler.Aux[B, ${`(A..N)`}], fu: Functor[M]): M[B] =
+        -      fu.map[${`A~N`}, B](combine(m1, m2))({ case ${`a~n`} => t.from(${`(a..n)`}) })
+        -
+        -    def tupled(implicit fu: Functor[M]): M[${`(A..N)`}] =
+        -      apply[${`(A..N)`}]({ (${`a:A..n:N`}) => (${`a..n`}) })
         -  }
         -
         |}
@@ -174,11 +180,14 @@ object Boilerplate {
         -  class ContravariantSyntax${arity}[${`A..N`}](m1: M[${`A~N-1`}], m2: M[A${arity-1}]) {
         -    $next
         -
-        -    def apply[B](f: B => (${`A..N`}))(implicit fu: Contravariant[M]): M[B] =
-        -      fu.contramap(combine(m1, m2))((b: B) => { val (${`a..n`}) = f(b); ${`new ~(.., n)`} })
+        -    def apply[B](f: B => ${`(A..N)`})(implicit fu: Contravariant[M]): M[B] =
+        -      fu.contramap[${`A~N`}, B](combine(m1, m2))((b: B) => { val (${`a..n`}) = f(b); ${`new ~(.., n)`} })
         -
-        -    def tupled(implicit fu: Contravariant[M]): M[(${`A..N`})] =
-        -      apply[(${`A..N`})]({ (a: (${`A..N`})) => (${`a._1..a._N`}) })
+        -    def as[B](implicit t: CaseClassTupler.Aux[B, ${`(A..N)`}], fu: Contravariant[M]): M[B] =
+        -      fu.contramap[${`A~N`}, B](combine(m1, m2))((b: B) => { val (${`a..n`}) = t.to(b); ${`new ~(.., n)`} })
+        -
+        -    def tupled(implicit fu: Contravariant[M]): M[${`(A..N)`}] =
+        -      apply[${`(A..N)`}]({ (a: ${`(A..N)`}) => (${`a._1..a._N`}) })
         -  }
         -
         |}

--- a/project/Boilerplate.scala
+++ b/project/Boilerplate.scala
@@ -29,7 +29,9 @@ object Boilerplate {
   val templates: Seq[Template] = List(
     InvariantSyntax,
     FunctorSyntax,
-    ContravariantSyntax
+    ContravariantSyntax,
+    UFreeSyntax,
+    LiftInstances
   )
 
   /** Returns a seq of the generated files. As a side-effect, it actually generates them... */
@@ -188,6 +190,97 @@ object Boilerplate {
         -
         -    def tupled(implicit fu: Contravariant[M]): M[${`(A..N)`}] =
         -      apply[${`(A..N)`}]({ (a: ${`(A..N)`}) => (${`a._1..a._N`}) })
+        -  }
+        -
+        |}
+      """
+    }
+  }
+
+  object UFreeSyntax extends Template {
+    def filename(root: File) = root / "UFreeSyntax.scala"
+
+    def content(tv: TemplateVals) = {
+      import tv._
+
+      val `((A..N))` = synTypes.reduce[String] { case (acc, el) => s"($acc, $el)" }
+      val `((a..n))` = `((A..N))`.toLowerCase
+
+      val next = if (arity >= maxArity) "" else
+        s"""
+        |-    def ~[IX <: HList, IO <: HList, X]
+        |-      (fb: UFree.Aux[X, IX])
+        |-      (implicit p: UnliftPrepend.Aux[Implicits, IX, IO])
+        |-      : UFreeSyntax${arity + 1}[IO, ${`A..N`}, X] =
+        |-        UFreeSyntax${arity + 1}(UFree.Zip(fa, fb)(p): UFree.Aux[(${`((A..N))`}, X), IO])
+        """.trim.stripMargin
+
+      block"""
+        |package jto.validation
+        |package free
+        |
+        |object UFreeSyntax {
+        -  case class UFreeSyntax${arity}[Implicits <: HList, ${`A..N`}](fa: UFree.Aux[(${`((A..N))`}), Implicits]) {
+        -    def imap[X](f: ${`(A..N)`} => X, g: X => (${`(A..N)`})): UFree.Aux[X, Implicits] =
+        -      UFree.Imap(fa)(
+        -        { case ${`((a..n))`} => f(${`a..n`}) },
+        -        { x =>
+        -          val ${`(a..n)`} = g(x)
+        -          ${`((a..n))`}
+        -        })
+        -
+        -    def as[X](implicit t: CaseClassTupler.Aux[X, ${`(A..N)`}]): UFree.Aux[X, Implicits] =
+        -      UFree.Imap(fa)(
+        -        { case ${`((a..n))`} => t.from(${`(a..n)`}) },
+        -        { x =>
+        -          val ${`(a..n)`} = t.to(x)
+        -          ${`((a..n))`}
+        -        })
+        -
+        $next
+        -  }
+        -
+        |}
+      """
+    }
+  }
+
+  object LiftInstances extends Template {
+    def filename(root: File) = root / "LiftInstances.scala"
+
+    def content(tv: TemplateVals) = {
+      import tv._
+
+      val `A::N` = synTypes.mkString(" :: ")
+      val `a::n` = `A::N`.toLowerCase
+      val `P=>F[A]..P=>F[N]` = synTypes.map(t => s"(Path=>F[$t])").mkString(" :: ")
+      val `a:P=>F[A]..n:P=>F[N]` = synVals.zip(synTypes).map { case (a, t) => s"$a: Path=>F[$t]"}.mkString(", ")
+
+      block"""
+        |package jto.validation
+        |package free
+        |
+        |import cats._
+        |
+        |trait LiftInstances {
+        |  implicit class liftHList1[A, A0](self: UFree.Aux[A, A0 :: HNil]) {
+        |    def materialize[F[_]: InvariantMonoidal](implicit a0: Path=>F[A0]): F[A] =
+        |      self.mat(
+        |        new jto.validation.free.Lift[λ[t => Path=>F[t]], A0 :: HNil] {
+        |          type Out = (Path=>F[A0]) :: HNil
+        |          def instances = a0 :: HNil
+        |        }
+        |      )
+        |  }
+        |
+        -  implicit class liftHList${arity}[A, ${`A..N`}](self: UFree.Aux[A, ${`A::N`} :: HNil]) {
+        -    def materialize[F[_]: InvariantMonoidal](implicit ${`a:P=>F[A]..n:P=>F[N]`}): F[A] =
+        -      self.mat(
+        -        new jto.validation.free.Lift[λ[t => Path=>F[t]], ${`A::N`} :: HNil] {
+        -          type Out = ${`P=>F[A]..P=>F[N]`} :: HNil
+        -          def instances = ${`a::n`} :: HNil
+        -        }
+        -      )
         -  }
         -
         |}

--- a/validation-core/src/main/scala/CaseClassTupler.scala
+++ b/validation-core/src/main/scala/CaseClassTupler.scala
@@ -1,0 +1,52 @@
+package jto.validation
+
+/**
+ * Lightweight alternative to `shapeless.Generic` limited to products and targeting `TupleN`s.
+ */
+trait CaseClassTupler[T] {
+  type TupleRepr
+
+  def to(t: T): TupleRepr
+  def from(t: TupleRepr): T
+}
+
+object CaseClassTupler {
+  type Aux[T, R] = CaseClassTupler[T] { type TupleRepr = R }
+  def apply[T](implicit t: CaseClassTupler[T]): Aux[T, t.TupleRepr] = t
+
+  implicit def materialize[T, R]: Aux[T, R] = macro CaseClassTuplerMacro.mkCaseClassTupler[T, R]
+}
+
+object CaseClassTuplerMacro {
+  import scala.reflect.macros.whitebox.Context
+
+  def mkCaseClassTupler[T: c.WeakTypeTag, R: c.WeakTypeTag](c: Context): c.Tree = {
+    import c.universe._
+
+    val tpe: Type = weakTypeOf[T]
+    val helper = new { val context: c.type = c } with MappingMacros.Helper
+    import helper._
+
+    val (apply, unapply) = lookup[T]
+    val (_, constructorParamss) = getConstructorParamss[T]
+    val isArityOne: Boolean = constructorParamss.headOption.toList.flatten.size == 1
+
+    val TypeRef(_, _, ps) = unapply.returnType
+    val tupleRepr = tq"${ps.head}"
+
+    val to = q"""_root_.scala.Function.unlift($unapply _)(c)"""
+    val from = if (isArityOne) q"""$apply(t)""" else q"""($apply _).tupled(t)"""
+
+    val clsName = TypeName(c.freshName("anon$"))
+    q"""
+      {
+        final class $clsName extends _root_.jto.validation.CaseClassTupler[$tpe] {
+          type TupleRepr = $tupleRepr
+          def to(c: $tpe): TupleRepr   = $to
+          def from(t: TupleRepr): $tpe = $from
+        }
+        new $clsName(): _root_.jto.validation.CaseClassTupler.Aux[$tpe, $tupleRepr]
+      }
+    """
+  }
+}

--- a/validation-core/src/main/scala/DefaultRules.scala
+++ b/validation-core/src/main/scala/DefaultRules.scala
@@ -198,8 +198,7 @@ trait GenericRules {
           case (v, i) =>
             Rule.toRule(r).repath((Path \ i) ++ _).validate(v)
         }
-        import cats.std.list._
-        import cats.syntax.traverse._
+        import cats.implicits._
         withI.toList.sequenceU
     }
 
@@ -434,8 +433,7 @@ trait DefaultRules[I] extends GenericRules with DateRules {
             .validate(f._2)
             .map(f._1 -> _)
         }
-        import cats.std.list._
-        import cats.syntax.traverse._
+        import cats.implicits._
         validations.toList.sequenceU.map(_.toMap)
       })
   }

--- a/validation-core/src/main/scala/MappingMacros.scala
+++ b/validation-core/src/main/scala/MappingMacros.scala
@@ -3,7 +3,7 @@ package jto.validation
 object MappingMacros {
   import scala.reflect.macros.blackbox.Context
 
-  private abstract class Helper {
+  private[validation] abstract class Helper {
     val context: Context
     import context.universe._
 
@@ -117,10 +117,10 @@ object MappingMacros {
         val typeApply = ts.foldLeft(q"$w1 ~ $w2") { (t1, t2) =>
           q"$t1 ~ $t2"
         }
-        q"($typeApply)(Function.unlift($unapply(_)))"
+        q"($typeApply)(_root_.scala.Function.unlift($unapply(_)))"
 
       case w1 :: Nil =>
-        q"$w1.contramap(Function.unlift($unapply(_)): $t)"
+        q"$w1.contramap(_root_.scala.Function.unlift($unapply(_)): $t)"
     }
 
     // XXX: recursive values need the user to use explcitly typed implicit val

--- a/validation-core/src/main/scala/backcompat.scala
+++ b/validation-core/src/main/scala/backcompat.scala
@@ -136,7 +136,7 @@ object Validation {
   @deprecated("use .toList.sequenceU", "2.0")
   def sequence[E, A](
       vs: Seq[Validated[Seq[E], A]]): Validated[Seq[E], Seq[A]] = {
-    import cats.std.list._; import cats.syntax.traverse._;
+    import cats.implicits._
     vs.toList.sequenceU
   }
 }

--- a/validation-core/src/main/scala/free/HList.scala
+++ b/validation-core/src/main/scala/free/HList.scala
@@ -1,0 +1,107 @@
+package jto.validation
+package free
+
+/**
+  * `HList`. Inspired from the shapeless implementation:
+  * https://github.com/milessabin/shapeless/blob/shapeless-2.3.1/core/src/test/scala/shapeless/hlist.scala
+  *
+  * Copyright (c) 2011-14 Miles Sabin
+  * Licensed under the Apache 2 license, http://www.apache.org/licenses/LICENSE-2.0.
+  */
+sealed trait HList
+
+object HList {
+  implicit class ConsHList[L <: HList](l: L) {
+    def ::[H](h : H): H :: L = HCons(h, l)
+  }
+}
+
+sealed trait ::[+H, +T <: HList] extends HList {
+  def head: H
+  def tail: T
+}
+final case class HCons[+H, +T <: HList](head: H, tail: T) extends ::[H, T]
+
+sealed trait HNil extends HList
+final case object HNil extends HNil
+
+/**
+  * `Lift` is a non-sealed equivalent to `shapeless.ops.hlist.LiftAll`, with the addition of the
+  * `split` method to deconstruct a `Lift[F, H :: T]` into `(F[H], Lift[F, T])`.
+  */
+trait Lift[F[_], In <: HList] { self =>
+  type Out <: HList
+  def instances: Out
+
+  def cons[A](fa: F[A]): Lift.Aux[F, A :: In, F[A] :: Out] =
+    new Lift[F, A :: In] {
+      type Out = F[A] :: self.Out
+      def instances = fa :: self.instances
+    }
+}
+
+object Lift {
+  type Aux[F[_], In0 <: HList, Out0 <: HList] = Lift[F, In0] { type Out = Out0 }
+
+  def apply[F[_], In <: HList](implicit l: Lift[F, In]): Lift[F, In] = l
+
+  def empty[F[_]]: Lift.Aux[F, HNil, HNil] =
+    new Lift[F, HNil] {
+      type Out = HNil
+      def instances = HNil
+    }
+
+  implicit class LiftSplit[F[_], H, T <: HList](self: Lift[F, H :: T]) {
+    def split: (F[H], Lift[F, T]) = {
+      val HCons(h, t) = self.instances
+      (
+        h.asInstanceOf[F[H]], // By definition of Lift
+        new Lift[F, T] { type Out = t.type; def instances = t }
+      )
+    }
+  }
+}
+
+/**
+ * `UnliftPrepend` has the same functionalities than `shapeless.ops.hlists.Prepend`, with the addition
+ * of the `unlift` methods which splits a `Lift[F, P ::: S]` in `(Lift[F, P], Lift[F, S])`.
+ */
+trait UnliftPrepend[P <: HList, S <: HList] {
+  def prepend(prefix: P, suffix: S): Out
+
+  def unlift[F[_]](la: Lift[F, Out]): (Lift[F, P], Lift[F, S])
+
+  type Out <: HList
+}
+
+trait LowPriorityUnliftPrepend {
+  type Aux[P <: HList, S <: HList, Out0 <: HList] = UnliftPrepend[P, S] { type Out = Out0 }
+
+  implicit def hlistUnliftPrepend[PH, PT <: HList, S <: HList]
+    (implicit pt: UnliftPrepend[PT, S]): UnliftPrepend.Aux[PH :: PT, S, PH :: pt.Out] =
+      new UnliftPrepend[PH :: PT, S] {
+        type Out = PH :: pt.Out
+
+        def prepend(prefix: PH :: PT, suffix: S): Out =
+          HCons(prefix.head, pt.prepend(prefix.tail, suffix))
+
+        def unlift[F[_]](la: Lift[F, Out]): (Lift[F, PH :: PT], Lift[F, S]) = {
+          val (fa, lt) = la.split
+          val (pf, sf) = pt.unlift(lt)
+          (pf.cons(fa), sf)
+        }
+      }
+}
+
+object UnliftPrepend extends LowPriorityUnliftPrepend {
+  def apply[P <: HList, S <: HList](implicit p: UnliftPrepend[P, S]): UnliftPrepend[P, S] = p
+
+  implicit def hnilUnliftPrepend1[S <: HList]: UnliftPrepend.Aux[HNil, S, S] =
+    new UnliftPrepend[HNil, S] {
+      type Out = S
+
+      def prepend(prefix: HNil, suffix: S): S = suffix
+
+      def unlift[F[_]](la: Lift[F, Out]): (Lift[F, HNil], Lift[F, S]) = (Lift.empty, la)
+    }
+}

--- a/validation-core/src/main/scala/free/UFree.scala
+++ b/validation-core/src/main/scala/free/UFree.scala
@@ -1,0 +1,112 @@
+package jto.validation
+package free
+
+import cats.InvariantMonoidal
+import cats.syntax.all._
+import jto.validation._
+
+/**
+  * Uncontrained Free to build validation like structure.
+  *
+  * Contrary to `Free` tranditional free structures, `UFree` are not tight to a particular ADT.
+  *
+  * {{{
+  * // Example data type
+  * case class Foo(b: Boolean, s: String, i: Int)
+  *
+  * // UFree expression, built with internal algebra.
+  * val fa: UFree[Foo] =
+  *   Imap(
+  *     Zip(
+  *       Zip(
+  *         Leaf(Path \ "boolean_field")[Boolean],
+  *         Leaf(Path \ "string_field")[String]
+  *       ),
+  *       Leaf(Path \ "int_field")[Int]
+  *     )
+  *   )(
+  *     { case ((b, s), i)  => Foo(b, s, i) }
+  *     { case Foo(b, s, i) => ((b, s), i)  }
+  *   )
+  *
+  * // Summons and assembles Show[Boolean], Show[String] and Show[Int]
+  * val a: Show[Foo] = fa.materialize[Show]
+  * }}}
+  *
+  * `|@|`/`~` style syntax is available, implemented via the statically generated `UFreeSyntaxN`.
+  * Note that `.materialize` reports precise errors about missing implicits.
+  */
+sealed trait UFree[A] {
+  type Implicits <: HList
+
+  private[validation] def mat[F[_]: InvariantMonoidal](lift: Lift[λ[t => Path=>F[t]], Implicits]): F[A]
+
+  private[validation] def rePath(path: Path): UFree.Aux[A, Implicits]
+
+  def ~[IB <: HList, IO <: HList, B]
+    (fb: UFree.Aux[B, IB])
+    (implicit p: UnliftPrepend.Aux[Implicits, IB, IO])
+    : UFreeSyntax.UFreeSyntax2[IO, A, B] =
+      UFreeSyntax.UFreeSyntax2(UFree.Zip(this: this.type, fb)(p))
+
+  def imap[X](f: A => X, g: X => A): UFree.Aux[X, Implicits] =
+    UFree.Imap(this: this.type)(f, g)
+
+  def as[X](implicit t: CaseClassTupler.Aux[X, A]): UFree.Aux[X, Implicits] =
+    imap(t.from, t.to)
+}
+
+trait LowPrioUFree {
+  /** Calling `implicitly[UFree[A]]` generated a leaf, unless there is implicit `UFree` which higher priority. */
+  implicit def freeAsLeaf[A]: UFree.Leaf[A] = UFree.Leaf[A](Path)
+}
+
+object UFree extends LiftInstances with LowPrioUFree {
+  type Aux[A, I] = UFree[A] { type Implicits = I }
+
+  /** Generates a `UFree` with case class fields as leafs labels using a macro. */
+  def gen[A]: GenUFreeCurried[A] = new GenUFreeCurried[A]()
+
+  private[validation] class GenUFreeCurried[A] {
+    def apply[I](): Aux[A, I] = macro UFreeMacro.free[A, I]
+  }
+
+  private[validation] case class Leaf[A](path: Path) extends UFree[A] {
+    type Implicits = A :: HNil
+
+    private[validation] def rePath(p: Path): UFree.Aux[A, A :: HNil] =
+      this.copy(path = p ++ path)
+
+    private[validation] def mat[F[_]: InvariantMonoidal](lift: Lift[λ[t => Path=>F[t]], A :: HNil]): F[A] =
+      lift.instances.asInstanceOf[(Path=>F[A]) :: HNil].head.apply(path)
+  }
+
+  private[validation] case class Zip[IA <: HList, IB <: HList, IO <: HList, A, B]
+    (fa: UFree.Aux[A, IA], fb: UFree.Aux[B, IB])
+    (implicit p: UnliftPrepend.Aux[IA, IB, IO])
+    extends UFree[(A, B)] {
+      type Implicits = IO
+
+      private[validation] def rePath(path: Path): UFree.Aux[(A, B), IO] =
+        Zip[IA, IB, IO, A, B](fa.rePath(path), fb.rePath(path))(p)
+
+      private[validation] def mat[F[_]: InvariantMonoidal](lift: Lift[λ[t => Path=>F[t]], IO]): F[(A, B)] = {
+        type ManualHighOrderUnification[t] = Path=>F[t]
+        implicit val (la, lb) = p.unlift(lift: Lift[ManualHighOrderUnification, IO])
+        fa.mat[F](la).product(fb.mat[F](lb))
+      }
+    }
+
+  private[validation] case class Imap[IA <: HList, A, B]
+    (fa: UFree.Aux[A, IA])
+    (f: A => B, g: B => A)
+    extends UFree[B] {
+      type Implicits = IA
+
+      private[validation] def rePath(path: Path): UFree.Aux[B, IA] =
+        Imap(fa.rePath(path))(f, g)
+
+      private[validation] def mat[F[_]: InvariantMonoidal](lift: Lift[λ[t => Path=>F[t]], IA]): F[B] =
+        fa.mat[F](lift).imap(f)(g)
+    }
+}

--- a/validation-core/src/main/scala/free/UFreeMacro.scala
+++ b/validation-core/src/main/scala/free/UFreeMacro.scala
@@ -1,0 +1,26 @@
+package jto.validation
+package free
+
+object UFreeMacro {
+  import scala.reflect.macros.whitebox.Context
+
+  def free[X: c.WeakTypeTag, Implicits](c: Context)(): c.Tree = {
+    import c.universe._
+
+    val helper = new { val context: c.type = c } with MappingMacros.Helper
+    import helper._
+
+    val (_, constructorParamss) = getConstructorParamss[X]
+
+    val leafs: List[Tree] =
+      for { g <- constructorParamss.headOption.toList; param <- g } yield {
+        val term = param.asTerm
+        val name = q"""${term.name.toString}"""
+        q"""(_root_.jto.validation.Path \ $name).as[${term.typeSignature}]"""
+      }
+
+    val body = leafs.reduce((t1, t2) => q"$t1 ~ $t2")
+    val typeX = weakTypeOf[X].dealias
+    q"""$body.as[$typeX]"""
+  }
+}

--- a/validation-core/src/main/scala/free/package.scala
+++ b/validation-core/src/main/scala/free/package.scala
@@ -1,0 +1,41 @@
+package jto.validation
+
+import cats._
+
+// This file will be empty when things are properly merged into validation-core.
+
+package object free {
+  /** To be moved in Write companion object. */
+  implicit def invariantMonoidalWrite[O: Monoid]: InvariantMonoidal[Write[?, O]] =
+    new InvariantMonoidal[Write[?, O]] {
+      def product[A, B](fa: Write[A, O], fb: Write[B, O]): Write[(A, B), O] =
+        Write { case (a, b) => Monoid[O].combine(fa.writes(a), fb.writes(b)) }
+
+      def imap[A, B](fa: Write[A, O])(f: A => B)(g: B => A): Write[B, O] =
+        fa.contramap(g)
+
+      def pure[A](a: A): Write[A, O] =
+        Write(_ => Monoid[O].empty)
+    }
+
+  /** To be moved in Rule companion object. */
+  implicit def invariantMonoidalRule[I]: InvariantMonoidal[Rule[I, ?]] =
+    new InvariantMonoidal[Rule[I, ?]] {
+      def product[A, B](fa: Rule[I, A], fb: Rule[I, B]): Rule[I, (A, B)] =
+        fb.ap(fa.map(a => b => (a, b)))
+
+      def imap[A, B](fa: Rule[I, A])(f: A => B)(g: B => A): Rule[I, B] =
+        fa.map(f)
+
+      def pure[A](a: A): Rule[I, A] =
+        Rule(_ => Valid(a))
+    }
+
+  // To be added directly to Path.
+  implicit class PathAt(path: Path) {
+    def as[A](implicit f: UFree[A]): UFree.Aux[A, f.Implicits] = f.rePath(path)
+  }
+
+  // Not sure what do to with this one...
+  val __ = Path
+}

--- a/validation-core/src/test/scala/CaseClassTuplerSpec.scala
+++ b/validation-core/src/test/scala/CaseClassTuplerSpec.scala
@@ -1,0 +1,65 @@
+import org.scalatest._
+import jto.validation._
+
+class CaseClassTuplerSpec extends WordSpec with Matchers {
+  "CaseClassTupler" should {
+    "round trip for small example" in {
+      val tupler = CaseClassTupler[Toto]
+      implicitly[tupler.TupleRepr =:= (String, Int)]
+
+      val toto  = Toto("s", 1)
+      val tuple = ("s", 1)
+      assert(tupler.to(toto)    == tuple)
+      assert(tupler.from(tuple) == toto)
+    }
+
+    "round trip with many fields" in {
+      val tupler = CaseClassTupler[X]
+      type S = String
+      implicitly[tupler.TupleRepr =:= (S, S, S, S, S, S, S, S, S, S, S, S, S, S, S, S, S, S, S, S, S)]
+
+      val x = X("1", "2", "3", "4", "5", "6", "7", "8", "9", "A", "B", "C", "D", "E", "F", "G", "H", "I", "J", "K", "L")
+      val t =  ("1", "2", "3", "4", "5", "6", "7", "8", "9", "A", "B", "C", "D", "E", "F", "G", "H", "I", "J", "K", "L")
+      assert(tupler.to(x)   == t)
+      assert(tupler.from(t) == x)
+    }
+
+    "single field case class" in {
+      val tupler = CaseClassTupler[Cat]
+      implicitly[tupler.TupleRepr =:= String]
+
+      val cat   = Cat("s")
+      val tuple = "s"
+      assert(tupler.to(cat)    == tuple)
+      assert(tupler.from(tuple) == cat)
+    }
+  }
+}
+
+case class Cat(name: String)
+
+case class Toto(s: String, i: Int)
+
+case class X(
+  _1: String,
+  _2: String,
+  _3: String,
+  _4: String,
+  _5: String,
+  _6: String,
+  _7: String,
+  _8: String,
+  _9: String,
+  _10: String,
+  _11: String,
+  _12: String,
+  _13: String,
+  _14: String,
+  _15: String,
+  _16: String,
+  _17: String,
+  _18: String,
+  _19: String,
+  _20: String,
+  _21: String
+)

--- a/validation-core/src/test/scala/ValidationSpec.scala
+++ b/validation-core/src/test/scala/ValidationSpec.scala
@@ -93,8 +93,7 @@ class ValidatedSpec extends WordSpec with Matchers {
       val s1: Validated[List[String], String] = Valid("1")
       val s2: Validated[List[String], String] = Valid("2")
 
-      import cats.std.list._
-      import cats.syntax.traverse._
+      import cats.implicits._
       List(s1, s2).sequenceU shouldBe (Valid(List("1", "2")))
       List(f1, f2).sequenceU shouldBe (Invalid(List("err1", "err2")))
     }

--- a/validation-jsonast/shared/src/test/scala/free/Instances.scala
+++ b/validation-jsonast/shared/src/test/scala/free/Instances.scala
@@ -1,0 +1,15 @@
+package jto.validation.free
+
+import cats._
+import jto.validation.jsonast._
+
+/** jsonast specific instances, once things are properly merged into validation-core. */
+object Instances {
+  implicit val jsValueMonoid: Monoid[JValue] =
+    new Monoid[JValue] {
+      def empty: JValue = JObject()
+
+      def combine(a: JValue, b: JValue): JValue =
+        jto.validation.jsonast.Writes.jsonMonoid.combine(a.asInstanceOf[JObject], b.asInstanceOf[JObject])
+    }
+}

--- a/validation-jsonast/shared/src/test/scala/free/UFreeSpec.scala
+++ b/validation-jsonast/shared/src/test/scala/free/UFreeSpec.scala
@@ -1,0 +1,198 @@
+package jto.validation.free
+
+import jto.validation._
+import jto.validation.jsonast._
+import jto.validation.jsonast.Rules._
+import jto.validation.jsonast.Writes._
+import org.scalatest._
+import Instances._
+
+case class MyCC1(int: Int, double: Double)
+case class MyCC2(mycc: MyCC1, boolean: Boolean)
+case class User(age: Int, name: String)
+case class Dog(name: String, master: User)
+case class Cat(name: String)
+case class OEmail(email: Option[String])
+
+case class Contact(
+  firstname: String,
+  lastname: String,
+  company: Option[String],
+  informations: Seq[ContactInformation]
+)
+
+case class ContactInformation(
+  label: String,
+  email: Option[String],
+  phones: Seq[String]
+)
+
+class UFreeSpec extends WordSpec with Matchers {
+  "UFree" should {
+    implicit val freeMyCC1 =
+      (
+        (__ \ "int_field").as[Int] ~
+        (__ \ "double_field").as[Double]
+      ).as[MyCC1]
+
+    implicitly[freeMyCC1.Implicits =:= (Int :: Double :: HNil)]
+    val mycc2: MyCC2 = MyCC2(MyCC1(1, 2.2), true)
+
+    implicit val freeUser = UFree.gen[User]()
+    val freeDog  = UFree.gen[Dog]()
+    implicitly[freeUser.Implicits =:= (Int :: String :: HNil)]
+    implicitly[freeDog.Implicits =:= (String :: Int :: String :: HNil)]
+
+    val freeContactInformation = UFree.gen[ContactInformation]()
+    val freeContact = UFree.gen[Contact]()
+    implicitly[freeContactInformation.Implicits =:= (String :: Option[String] :: Seq[String] :: HNil)]
+    implicitly[freeContact.Implicits =:= (String :: String :: Option[String] :: Seq[ContactInformation] :: HNil)]
+
+    "roundtrip flat composed case classes" in {
+      val ast2 =
+        (
+          (__).as[MyCC1] ~
+          (__ \ "boolean_field").as[Boolean]
+        ).as[MyCC2]
+
+      val ast2Typed: UFree[MyCC2] = ast2
+      implicitly[ast2.Implicits =:= (Int :: Double :: Boolean :: HNil)]
+
+      val rule2: Rule[JValue, MyCC2]   = ast2.materialize[Rule[JValue, ?]]
+      val write2: Write[MyCC2, JValue] = ast2.materialize[Write[?, JValue]]
+
+      val json2: JValue = write2.writes(mycc2)
+
+      println(json2)
+      assert(json2 == JObject(Map(
+        "int_field"     -> JNumber(1),
+        "double_field"  -> JNumber(2.2),
+        "boolean_field" -> JBoolean(true)
+      )))
+
+      val validated2 = rule2.validate(json2)
+      assert(validated2 == Valid(mycc2))
+    }
+
+    "roundtrip nested composed case classes" in {
+      val ast3 =
+        (
+          (__ \ "nested").as[MyCC1] ~
+          (__ \ "boolean_field").as[Boolean]
+        ).as[MyCC2]
+
+      val ast3Typed: UFree[MyCC2] = ast3
+      implicitly[ast3.Implicits =:= (Int :: Double :: Boolean :: HNil)]
+
+      val rule3: Rule[JValue, MyCC2]   = ast3.materialize[Rule[JValue, ?]]
+      val write3: Write[MyCC2, JValue] = ast3.materialize[Write[?, JValue]]
+
+      val mycc3: MyCC2 = MyCC2(MyCC1(1, 2.2), true)
+      val json3: JValue = write3.writes(mycc2)
+
+      println(json3)
+      assert(json3 == JObject(Map(
+        "nested" -> JObject(Map(
+          "int_field"    -> JNumber(1),
+          "double_field" -> JNumber(2.2)
+        )),
+        "boolean_field" -> JBoolean(true)
+      )))
+
+      val validated3 = rule3.validate(json3)
+
+      println(validated3)
+      assert(validated3 == Valid(mycc2))
+    }
+
+    "roundtrip macro generated case classes" in {
+      val ast4 = UFree.gen[MyCC2]()
+
+      val ast4Typed: UFree[MyCC2] = ast4
+      implicitly[ast4.Implicits =:= (Int :: Double :: Boolean :: HNil)]
+
+      val rule4: Rule[JValue, MyCC2]   = ast4.materialize[Rule[JValue, ?]]
+      val write4: Write[MyCC2, JValue] = ast4.materialize[Write[?, JValue]]
+
+      val mycc4: MyCC2 = MyCC2(MyCC1(1, 2.2), true)
+      val json4: JValue = write4.writes(mycc2)
+
+      println(json4)
+      assert(json4 == JObject(Map(
+        "mycc" -> JObject(Map(
+          "int_field"    -> JNumber(1),
+          "double_field" -> JNumber(2.2)
+        )),
+        "boolean" -> JBoolean(true)
+      )))
+
+      val validated4 = rule4.validate(json4)
+
+      println(validated4)
+      assert(validated4 == Valid(mycc2))
+    }
+
+    "handle option fields" in {
+      val freeOEmail = UFree.gen[OEmail]()
+
+      import Writes._
+      val w: Write[OEmail, JValue] = freeOEmail.materialize[Write[?, JValue]]
+      w.writes(OEmail(Some("Hello World"))) shouldBe JObject(Map("email" -> JString("Hello World")))
+      w.writes(OEmail(None)) shouldBe JObject(Map())
+
+      import Rules._
+      val r: Rule[JValue, OEmail] = freeOEmail.materialize[Rule[JValue, ?]]
+      r.validate(JObject(Map("email" -> JString("Hello World")))) shouldBe Valid(OEmail(Some("Hello World")))
+      r.validate(JObject(Map())) shouldBe Valid(OEmail(None))
+    }
+
+    "create a Rule[User]" in {
+      import Rules._
+      implicit val userReads = freeUser.materialize[Rule[JValue, ?]]
+      userReads.validate(JObject(Map("name" -> JString("toto"), "age" -> JNumber(45)))) shouldBe (Valid(User(45, "toto")))
+    }
+
+    "create a Write[User]" in {
+      import Writes._
+      implicit val userWrites = freeUser.materialize[Write[?, JValue]]
+      userWrites.writes(User(45, "toto")) shouldBe (JObject(Map("name" -> JString("toto"), "age" -> JNumber(45))))
+    }
+
+    "create a Rule[Dog]" in {
+      import Rules._
+      implicit val userRule = freeUser.materialize[Rule[JValue, ?]]
+      implicit val dogRule = freeDog.materialize[Rule[JValue, ?]]
+      dogRule.validate(JObject(Map("name" -> JString("medor"), "master" -> JObject(Map("name" -> JString("toto"), "age" -> JNumber(45)))))) shouldBe (Valid(Dog("medor", User(45, "toto"))))
+    }
+
+    "create a Write[Dog]" in {
+      import Writes._
+      implicit val userWrite = freeUser.materialize[Write[?, JValue]]
+      implicit val dogWrite = freeDog.materialize[Write[?, JValue]]
+      dogWrite.writes(Dog("medor", User(45, "toto"))) shouldBe (JObject(Map("name" -> JString("medor"), "master" -> JObject(Map("name" -> JString("toto"), "age" -> JNumber(45))))))
+    }
+
+    "create a Write" in {
+      implicit val contactInformationWrite: Write[ContactInformation, JValue] = freeContactInformation.materialize[Write[?, JValue]]
+      implicit val contactWrite: Write[Contact, JValue] = freeContact.materialize[Write[?, JValue]]
+
+      contactWrite.writes(
+        Contact(
+          "Julien",
+          "Tournay",
+          None,
+          Seq(ContactInformation("Personal",
+            Some("fakecontact@gmail.com"),
+            Seq("01.23.45.67.89", "98.76.54.32.10"))))
+      ) shouldBe JObject(Map(
+        "firstname" -> JString("Julien"),
+        "lastname" -> JString("Tournay"),
+        "informations" -> JArray(Seq(JObject(Map(
+          "label" -> JString("Personal"),
+          "email" -> JString("fakecontact@gmail.com"),
+          "phones" -> JArray(Seq(
+            JString("01.23.45.67.89"),
+            JString("98.76.54.32.10")))))))))
+    }
+  }
+}


### PR DESCRIPTION
This PR adds `UFree`, a free like structure which generalizes the DSL used in Validation (`From[JsValue]`, `To[JsObject]` and `Formatting[JsValue, JsObject]` expression). `UFree` expressions are not tied to a particular type class, which gives them great reusability:

``` scala
case class MyCC1(int: Int, double: Double)

val freeMyCC1 =
  (
    (__ \ "int_field").as[Int] ~
    (__ \ "double_field").as[Double]
  ).as[MyCC1]

val ruleJson:  Rule[JValue, MyCC1]  = freeMyCC1.materialize[Rule[JValue, ?]]
val ruleXml:   Rule[Node, MyCC1]    = freeMyCC1.materialize[Rule[Node, ?]]
val writeJson: Write[MyCC1, JValue] = freeMyCC1.materialize[Write[?, JValue]]
val writeXml:  Write[MyCC1, Node]   = freeMyCC1.materialize[Write[?, Node]]
val doc:       DocTC[MyCC1]         = freeMyCC1.materialize[DocTC]
```

The implementation uses shapeless dependent type operations over an `HList` to carry over the "leaf" types, such that they can be injected via a single step of implicit resolution at the very last moment (when calling `materialize`). This differs from the traditional approach using with free structure where free expressions and interpreters are tightly coupled to a particular ADT, which makes it nontrivial to extend the ADT or compose expressions and interpreters over different ADTs.

This is the status of what's covered by this PR:
- [x] Composing `UFree`
- [x] `.gen` style macro to generate `UFree` expression from data type definition
- [x] Expressive errors reporting in case of missing implicits for a data type
- [x] Equivalent handling of optional fields (not printed when absent, parsed as None when absent)
- [ ] Handing of recursive data types (I assumed that's non-blocker for a first iteration)

This work does not bring an extra dependency on shapeless (it uses a local version of `HList`), however it's currently build with a SNAPSHOT version of cats.

On top of #65 (the new commit is 3e7fd1fb5d664c3650cb97433f6747379f9744d4).
