### PR TITLE
Fix broken links & improve migration guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Being based on the same concepts as play's Json validation API, it should feel v
 
 The unified validation API is designed around a core defined in package `jto.validation`, and "extensions". Each extension provides primitives to validate and serialize data from / to a particular format ([Json](http://jto.github.io/validation/docs/book/ScalaValidationJson.html), [form encoded request body](http://jto.github.io/validation/docs/book/ScalaValidationMigrationForm.html), etc.). See [the extensions documentation](http://jto.github.io/validation/docs/book/ScalaValidationExtensions.html) for more information.
 
-To learn more about data validation, please consult [Validation and transformation with Rule](documentation/tut/ScalaValidationRule.md), for data serialization read [Serialization with Write](documentation/tut/ScalaValidationWrite.md). If you just want to figure all this out by yourself, please see the [Cookbook](documentation/tut/ScalaValidationCookbook.md).
+To learn more about data validation, please consult [Validation and transformation with Rule](docs/src/main/tut/ScalaValidationRule.md), for data serialization read [Serialization with Write](docs/src/main/tut/ScalaValidationWrite.md). If you just want to figure all this out by yourself, please see the [Cookbook](docs/src/main/tut/ScalaValidationCookbook.md).
 
 
 ## Using the validation api in your project

--- a/docs/src/main/tut/V2MigrationGuide.md
+++ b/docs/src/main/tut/V2MigrationGuide.md
@@ -20,8 +20,8 @@ becomes
 
 #### Package name
 
-- Since the library does not depend on Play anymore and is not planned to be integrated into Play, the package names have changed. Basically `play.api.mapping` now becomes `jto.validation`. A simple search and replace in your project should work.
-- The validation api support several json representations. Therefore, the package name for play json changes. `play.api.mapping.json` becomes `play.api.mapping.playjson`
+- Since the library does not depend on Play anymore and is not planned to be integrated into Play, the package names have changed. Basically `play.api.data.mapping` now becomes `jto.validation`. A simple search and replace in your project should work.
+- The validation api support several json representations. Therefore, the package name for play json changes. `play.api.data.mapping.json` becomes `play.api.mapping.playjson`
 
 #### Rule renaming
 


### PR DESCRIPTION
Fixes several links toward documentation, as well as the migration guide according to Play 2.5.x's API