### PR TITLE
Use key in pickChildsWithAttribute & pickChildWithAttribute

### DIFF
--- a/validation-xml/src/main/scala/Rules.scala
+++ b/validation-xml/src/main/scala/Rules.scala
@@ -93,7 +93,7 @@ trait Rules extends DefaultRules[Node] with ParsingRules {
       key: String, attrKey: String, attrValue: String)(
       implicit r: RuleLike[Node, O]): Rule[Node, Seq[O]] =
     Rule.fromMapping[Node, Seq[Node]] { node =>
-      Valid( (node \ "_").filter(_.attribute(attrKey).exists(_.text == attrValue)).toSeq )
+      Valid( (node \ key).filter(_.attribute(attrKey).exists(_.text == attrValue)).toSeq )
     }.andThen(seqR(r))
 
   def pickChildWithAttribute[O](
@@ -101,7 +101,7 @@ trait Rules extends DefaultRules[Node] with ParsingRules {
       implicit r: RuleLike[Node, O]): Rule[Node, O] =
     Rule
       .fromMapping[Node, Node] { node =>
-        val maybeChild = (node \ "_").find(
+        val maybeChild = (node \ key).find(
             _.attribute(attrKey).filter(_.text == attrValue).isDefined)
         maybeChild match {
           case Some(child) => Valid(child)

--- a/validation-xml/src/test/scala/RulesSpec.scala
+++ b/validation-xml/src/test/scala/RulesSpec.scala
@@ -492,6 +492,7 @@ class RulesSpec extends WordSpec with Matchers {
             <entity type="type1" name="Alexandre"></entity>
             <entity type="type2" name="Jean"></entity>
             <entity type="type1" name="Pierre"></entity>
+            <prop type="type1" name="Jean"></prop>
           </entities>
 
         val emptyXml =
@@ -514,6 +515,7 @@ class RulesSpec extends WordSpec with Matchers {
 
       "use attribute filtering to read first" in {
         val entityXml = <entity>
+            <entity name="age" value="24"></entity>
             <prop name="name" value="Alexandre"></prop>
             <prop name="age" value="25"></prop>
             <prop name="job" value="software engineer" type="fulltime"></prop>
@@ -528,6 +530,8 @@ class RulesSpec extends WordSpec with Matchers {
                   attributeR[Int]("value")
               )) tupled
         }
+
+        reads.validate(entityXml) shouldBe Valid( ("software engineer" -> "fulltime", 25) )
 
         val invalidXml = <entity>
             <prop name="name" value="Alexandre"></prop>


### PR DESCRIPTION
The `key` argument was not used in both Rule.