### PR TITLE
fix warning in build.sbt

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -143,7 +143,7 @@ val dependencies = Seq(
 )
 
 val generateBoilerplate = Seq(
-  sourceGenerators in Compile <+= (sourceManaged in Compile).map(Boilerplate.gen)
+  sourceGenerators in Compile += task(Boilerplate.gen((sourceManaged in Compile).value))
 )
 
 val doPublish = Seq(


### PR DESCRIPTION
https://travis-ci.org/jto/validation/builds/299230592#L906

```
/home/travis/build/jto/validation/build.sbt:146: warning: `<+=` operator is deprecated. Use `lhs += { x.value }`.
  sourceGenerators in Compile <+= (sourceManaged in Compile).map(Boilerplate.gen)
                              ^
```